### PR TITLE
feat: message signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ DEFINES   += U2F_MAX_MESSAGE_SIZE=264 #257+5+2
 DEFINES   += UNUSED\(x\)=\(void\)x
 DEFINES   += APPVERSION=\"$(APPVERSION)\"
 
+DEFINES   += CX_COMPLIANCE_141
+
 ##############
 #  Compiler  #
 ##############

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ APP_LOAD_PARAMS=--appFlags 0x40 --curve secp256k1 --path "44'/111'" --path "44'/
 
 APPVERSION_M=0
 APPVERSION_N=1
-APPVERSION_P=1
+APPVERSION_P=2
 APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
 
 #prepare hsm generation

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ endif
 include $(BOLOS_SDK)/Makefile.defines
 
 APPNAME = Ark
-APP_LOAD_PARAMS=--appFlags 0x40 --curve secp256k1 $(COMMON_LOAD_PARAMS)
+APP_LOAD_PARAMS=--appFlags 0x40 --curve secp256k1 --path "44'/111'" --path "44'/1'" $(COMMON_LOAD_PARAMS)
 
 APPVERSION_M=0
 APPVERSION_N=1
-APPVERSION_P=0
+APPVERSION_P=1
 APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
 
 #prepare hsm generation

--- a/src/main.c
+++ b/src/main.c
@@ -584,10 +584,18 @@ unsigned int io_seproxyhal_touch_tx_ok(const bagl_element_t *e) {
     if (tmpCtx.transactionContext.curve == CX_CURVE_256K1) {
         cx_sha256_init(&localHash);
         cx_hash(&localHash.header, CX_LAST, tmpCtx.transactionContext.rawTx, tmpCtx.transactionContext.rawTxLength, finalhash);
+#if CX_APILEVEL >= 8
+        tx = cx_ecdsa_sign(&privateKey, CX_RND_RFC6979 | CX_LAST, CX_SHA256, finalhash, sizeof(finalhash), G_io_apdu_buffer, NULL);
+#else        
         tx = cx_ecdsa_sign(&privateKey, CX_RND_RFC6979 | CX_LAST, CX_SHA256, finalhash, sizeof(finalhash), G_io_apdu_buffer);
         G_io_apdu_buffer[0] = 0x30;
+#endif        
     } else {
+#if CX_APILEVEL >= 8
+        tx = cx_eddsa_sign(&privateKey, CX_LAST, CX_SHA512, tmpCtx.transactionContext.rawTx, tmpCtx.transactionContext.rawTxLength, NULL, 0, G_io_apdu_buffer, NULL);
+#else        
         tx = cx_eddsa_sign(&privateKey, NULL, CX_LAST, CX_SHA512, tmpCtx.transactionContext.rawTx, tmpCtx.transactionContext.rawTxLength, G_io_apdu_buffer);
+#endif        
     }
 
     os_memset(&privateKey, 0, sizeof(privateKey));


### PR DESCRIPTION
Allows to sign messages with the instruction code `0x08`.

Example with message `Lorem ipsum`:
```
HID => e008804020058000002c800000018000000000000000000000004c6f72656d20697073756d
HID <= 30440220525d9b1998d3446d49a619f25f9a3c7cb8ff4e47957d2cd57b1eeee53a7875c902201366e8f146e0aa65d611c871a968eea79a74472dda90f5f8aba379ff4f2b75ef9000
```
If it's a longer message which can't be fully displayed, the text will do a "roundtrip" like when signing a tx.

This https://github.com/ArkEcosystem/desktop-wallet/blob/master/LedgerArk.js#L108 should theoretically work now, but I haven't been able to test it since some older dependency refuses to compile on my machine. 