### PR TITLE
[wip]chore: improve security 

### DIFF
--- a/src/approval.c
+++ b/src/approval.c
@@ -46,36 +46,36 @@ unsigned int ioApprove(const bagl_element_t *e) {
     cx_ecfp_private_key_t privateKey;
     uint8_t privateKeyData[HASH_64_LENGTH];
 
-    os_perso_derive_node_bip32(CX_CURVE_256K1,
-                               tmpCtx.signing.bip32Path,
-                               tmpCtx.signing.pathLength,
-                               privateKeyData,
-                               NULL);
+    TRY {
+        os_perso_derive_node_bip32(CX_CURVE_256K1,
+                                tmpCtx.signing.bip32Path,
+                                tmpCtx.signing.pathLength,
+                                privateKeyData,
+                                NULL);
 
-    cx_ecfp_init_private_key(tmpCtx.signing.curve,
-                             privateKeyData,
-                             HASH_32_LENGTH,
-                             &privateKey);
+        cx_ecfp_init_private_key(tmpCtx.signing.curve,
+                                privateKeyData,
+                                HASH_32_LENGTH,
+                                &privateKey);
 
-    os_memset(privateKeyData, 0, sizeof(privateKeyData));
+        os_memset(privateKeyData, 0, sizeof(privateKeyData));
 
 
-    setPublicKeyContext(&tmpCtx.publicKey, G_io_apdu_buffer);
+        setPublicKeyContext(&tmpCtx.publicKey, G_io_apdu_buffer);
 
-    if (tmpCtx.signing.curve == CX_CURVE_256K1) {
-        cx_sha256_t hashCtx;
-        uint8_t hash[CX_SHA256_SIZE];
-        hash256(&hashCtx,
-                tmpCtx.signing.data,
-                tmpCtx.signing.dataLength,
-                hash);
+        if (tmpCtx.signing.curve == CX_CURVE_256K1) {
+            cx_sha256_t hashCtx;
+            uint8_t hash[CX_SHA256_SIZE];
+            hash256(&hashCtx,
+                    tmpCtx.signing.data,
+                    tmpCtx.signing.dataLength,
+                    hash);
 
-        tx = signEcdsa(&privateKey, hash,
-                       G_io_apdu_buffer,
-                       sizeof(G_io_apdu_buffer));
-    }
-
-    os_memset(&privateKey, 0, sizeof(privateKey));
+            tx = signEcdsa(&privateKey, hash,
+                        G_io_apdu_buffer,
+                        sizeof(G_io_apdu_buffer));
+        }
+    } FINALLY { explicit_bzero(&privateKey, sizeof(privateKey)) }
 
     G_io_apdu_buffer[tx++] = 0x90;
     G_io_apdu_buffer[tx++] = 0x00;

--- a/src/approval.c
+++ b/src/approval.c
@@ -60,7 +60,6 @@ unsigned int ioApprove(const bagl_element_t *e) {
 
         os_memset(privateKeyData, 0, sizeof(privateKeyData));
 
-
         setPublicKeyContext(&tmpCtx.publicKey, G_io_apdu_buffer);
 
         if (tmpCtx.signing.curve == CX_CURVE_256K1) {
@@ -75,7 +74,10 @@ unsigned int ioApprove(const bagl_element_t *e) {
                         G_io_apdu_buffer,
                         sizeof(G_io_apdu_buffer));
         }
-    } FINALLY { explicit_bzero(&privateKey, sizeof(privateKey)) }
+    } FINALLY {
+        explicit_bzero(&privateKey, sizeof(privateKey));
+        explicit_bzero(&privateKeyData, sizeof(privateKeyData));
+    }
 
     G_io_apdu_buffer[tx++] = 0x90;
     G_io_apdu_buffer[tx++] = 0x00;

--- a/src/operations.c
+++ b/src/operations.c
@@ -151,7 +151,10 @@ static void handlePublicKeyContext(volatile unsigned int *tx) {
             *tx = setPublicKeyContext(&tmpCtx.publicKey, G_io_apdu_buffer);
             THROW(0x9000);
         }
-    } FINALLY { explicit_bzero(&privateKey, sizeof(privateKey)) }
+    } FINALLY {
+        explicit_bzero(&privateKey, sizeof(privateKey));
+        explicit_bzero(&privateKeyData, sizeof(privateKeyData));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/operations/transactions/deserializer.c
+++ b/src/operations/transactions/deserializer.c
@@ -218,7 +218,7 @@ StreamStatus deserialize(const uint8_t *buffer, const uint32_t length) {
         }
 
         CATCH_OTHER(e) {
-            os_memset(&transaction, 0U, sizeof(Transaction));
+            explicit_bzero(&transaction, sizeof(Transaction));
             result = USTREAM_FAULT;
         }
 


### PR DESCRIPTION
## Summary

Ledger recently released some security docs that highlight several important considerations:
-   [Ledger Docs: Security Guidelines](https://ledger.readthedocs.io/en/latest/additional/security_guidelines.html)

Fortunately, it looks like much of it won't apply to us.
-   we don't RYO primitives.
-   we enforce bip32 properly.
-   we don't currently use multiple APDU exchanges for single operations.
-   we don't use hashes to verify against a client.
-   the VendorField feat PR _does_ truncate large vendorFields, but the rest of the Transfer values are deserialized and displayed on-device.
-   the only macros we use unpack uint**x**_t's and are native to the Ledger SDK .
-   we check for over/underflows.
-   we're fairly strict on deserialization, though additional checks could be implemented in this PR.

There are, however, a few areas where adding/switching to `explicit_bzero` to clear important variables has the benefit of not being vulnerable to compiler optimizations.

As labeled, this PR is **WIP** and is open to suggestions.
I'm sure there are areas where we can beef up security.

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
