### PR TITLE
chore: add vagrant build option and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 -   implement v2 Transactions ([#27])
+-   added build options and documentation ([#32])
 
 ### Changed
 -   merged updates from LedgerHQ/ledger-app-ark ([#23])
@@ -17,4 +18,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#23]: https://github.com/ArkEcosystem/ledger/pull/23
 [#25]: https://github.com/ArkEcosystem/ledger/pull/25
 [#27]: https://github.com/ArkEcosystem/ledger/pull/27
+[#32]: https://github.com/ArkEcosystem/ledger/pull/32
 [unreleased]: https://github.com/ArkEcosystem/ledger/compare/master...develop

--- a/README.md
+++ b/README.md
@@ -1,19 +1,214 @@
 # ARK Ledger
 
-> A simple Ledger (Blue/NanoS/NanoX) App for the Ark Blockchain.
+> A simple Ledger NanoS/NanoX app for the ARK Blockchain.
 
+[![GitHub Actions](https://github.com/ArkEcosystem/ledger/workflows/CI/badge.svg)](https://github.com/ArkEcosystem/ledger)
 [![License: MIT](https://badgen.now.sh/badge/license/MIT/green)](https://opensource.org/licenses/MIT)
 
-Under development
+<!--ts-->
+  * [The Ledger ARK app](#the-ledger-ark-app)
+  * [Learning Resources](#learning-resources)
+    * [The Ledger Docs](#the-ledger-docs)
+    * [The NanoS Secure SDK](#the-nanos-secure-sdk)
+    * [More Ledger Apps](#the-nanos-secure-sdk)
+    * [Further Reading](#further-reading)
+  * [The Vagrant Development Environment](#the-ledger-vagrant-environment)
+    * [Requirements](#requirements)
+    * [Installing Vagrant and VirtualBox](#installing-vagrant-and-virtualbox)
+    * [Initializing the Ledger-Vagrant Machine](#initializing-the-ledger-vagrant-machine)
+    * [Connecting to the Vagrant machine](#connecting-to-the-vagrant-machine)
+    * [Vagrant Troubleshooting](#vagrant-troubleshooting)
+  * [Building and Flashing](#building-and-flashing)
+    * [Building the Ledger ARK app](#building-the-ledger-ark-app)
+    * [Flashing the Ledger ARK app](#flashing-the-ledger-ark-app)
+    * [Rebuilding and Flashing Changes](#rebuilding-and-flashing-changes)
+  * [Debugging](#debugging)
+  * [Security](#security)
+  * [Credits](#credits)
+  * [License](#license)
 
-## Install Development Environment
+<!--te-->
 
--   Install ledger vagrant https://github.com/fix/ledger-vagrant
--   Clone this repo under `apps/`
--   Connect to the vagrant machine `vagrant ssh`
--   Move to the app `cd apps/ark-ledger`
--   Connect your ledger Nano S
--   Install the app `sh ./rebuild.sh` (ie. build, delete and load app on ledger)
+## The Ledger ARK app
+
+This app is written in C for the Ledger NanoS and NanoX devices.
+
+While the Ledger ARK app _is_ compatible with the Ledger NanoX, there is currently no way to load a custom app until LedgerHQ releases the nanox-sdk's.  
+The Ledger NanoS—however—is fully supported for development and flashing.
+
+
+## Learning Resources
+
+This section contains some useful resources for learning about Ledger and embedded development—which is especially nuanced and requires additional considerations beyond typical crypto development.
+
+This is by no means an exhaustive list, but aims to provide some key materials.
+
+---
+
+### The Ledger Docs
+
+The Ledger Docs are by far the best place to start.
+
+They cover anything from how a Ledger works, to publishing a Ledger Application, to secure app development.
+
+***Be sure to read the Ledger Security Guidelines.**  
+It covers many concerns that would typically not be obvious, and is something that should be read more than once.
+
+-   [Ledger Documentation Hub](https://ledger.readthedocs.io/en/latest/index.html)
+-   [Ledger Documentation Hub: BOLOS](https://ledger.readthedocs.io/en/latest/bolos/features.html)
+-   [***Ledger Documentation Hub: Security Guidelines**](https://ledger.readthedocs.io/en/latest/additional/security_guidelines.html)
+
+---
+
+### The NanoS Secure SDK
+
+-   [GitHub: Ledger NanoS Secure SDK](https://github.com/LedgerHQ/nanos-secure-sdk)
+
+---
+
+### More Ledger Apps
+
+-   [Github: LedgerHQ Ledger Apps](https://github.com/LedgerHQ?q=ledger-app)
+
+---
+
+### Further Reading
+
+-   [ARM Developer Docs: The Arm C and C++ Libraries](https://developer.arm.com/docs/dui0475/i/the-arm-c-and-c-libraries)
+-   [C Library ABI for the ARM (PDF)](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0039d/IHI0039D_clibabi.pdf)
+-   [Stanford Wiki: AVR Programming](https://ccrma.stanford.edu/wiki/AVR_Programming)
+
+## The Vagrant Development Environment
+
+Although the Vagrant environment is optional, it is highly recommended for development.  
+i.e. we _can_ use Python & the [ledgerblue CLI](https://github.com/LedgerHQ/blue-loader-python), but using Vagrant keeps the host system safe from unwanted modification and ensures code portability.
+
+The projects `src/`, `example/`, and `glyphs/` folders are configured to sync with the Vagrant shell, so any changes to files in those directories will be updated to the development environment accordingly.  
+At this time, the rebuild script and the Makefile do not sync. Modifying those files requires calling `vagrant halt && vagrant up --provision` from outside the shell.
+
+---
+
+### Requirements
+-   Ledger Nano S
+-   Vagrant
+-   VirtualBox
+
+---
+
+### Installing Vagrant and VirtualBox
+
+**Linux**:
+```shell
+sudo apt install virtualbox
+sudo apt install vagrant
+```
+
+**macOS**:
+```shell
+brew cask install virtualbox
+brew cask install vagrant
+```
+
+**Windows**:
+
+1) Download and run the installer:
+  `https://download.virtualbox.org/virtualbox/6.0.10/VirtualBox-6.0.10-132072-Win.exe`
+2) Download and install the Oracle VM VirtualBox Extension Pack:
+  `https://download.virtualbox.org/virtualbox/6.0.10/Oracle_VM_VirtualBox_Extension_Pack-6.0.10.vbox-extpack`
+3) Download and run the Vagrant installer:
+  `https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.msi`
+
+---
+
+### Initializing the Ledger-Vagrant Machine
+
+```shell
+vagrant up
+```
+
+_note: setup will take a few minutes to provision._
+
+---
+
+### Connecting to the Vagrant machine
+
+```shell
+vagrant ssh
+```
+
+---
+
+### Vagrant Troubleshooting
+
+**USB Port locked out of the host machine**:
+
+-   Try restarting the Vagrant Box from outside the shell.
+    -   `vagrant halt && vagrant up`
+
+**Ledger not found in the Vagrant Box**:
+-   On Ubuntu, if the Ledger is not found in the vagrant box, ensure that the **host** user belongs to the vboxusers group.
+    -   `sudo usermod -aG vboxusers <username>`  
+(_see [askubuntu.com/How to set up USB for VirtualBox](https://askubuntu.com/questions/25596/how-to-set-up-usb-for-virtualbox/25600#25600)_)
+-   Try another USB Cable. Prefer the Ledger-supplied cable.  
+    Not all USB cables are created equal; and though rare, compromised cables have been found in the wild.
+
+## Building and Flashing
+
+Connect the Ledger device in before flashing.
+
+The Build and Flash commands are executed from project root:
+
+**Vagrant Shell**:
+-   `apps/ledger-app-ark`
+
+**ledgerblue CLI**:
+-   `ledger-app-ark`
+
+---
+
+### Building the Ledger ARK app
+
+```shell
+make
+```
+
+---
+
+### Flashing the Ledger ARK app
+
+```shell
+make && make load
+```
+
+---
+
+### Rebuilding and Flashing Changes
+
+This is the go-to script to push changes to a Ledger device.  
+It cleans, builds, deletes and reflashes the app.
+
+```shell
+sh ./rebuild.sh
+```
+
+## Debugging
+
+Along the way, debugging can save a lot of headaches when developing for embedded environments like Ledger.
+
+Specifically, Debugging on Ledger allows:
+-   Use of **PRINTF** and Console printing.
+-   Custom Certificates.
+-   Session Pin-bypass.
+
+See the following for more information on setting up debugging:
+-   [**Ledger Documentation Hub: Debugging**](https://ledger.readthedocs.io/en/latest/userspace/debugging.html)
+
+***Be sure to also enable Debugging in the projects Makefile**:
+
+```make
+# DEBUG = 0  # <-- ln87
+DEBUG = 1
+```
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > A simple Ledger NanoS/NanoX app for the ARK Blockchain.
 
-[![GitHub Actions](https://github.com/ArkEcosystem/ledger/workflows/CI/badge.svg)](https://github.com/ArkEcosystem/ledger)
 [![License: MIT](https://badgen.now.sh/badge/license/MIT/green)](https://opensource.org/licenses/MIT)
 
 <!--ts-->

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,52 @@
+Vagrant.configure("2") do |config|
+
+    # Specify the base box
+    config.vm.box = "ubuntu/bionic64"
+    config.vm.box_version = "20190814.0.0"
+
+    # set the `app`, `examples`, `glyphs`, and `src` folders for syncing
+    config.vm.synced_folder("apps/", "/home/vagrant/apps/",
+                            id: "appsdir",
+                            :create => true,
+                            type: "virtualbox")
+    config.vm.synced_folder("examples/", "/home/vagrant/apps/ledger-app-ark/examples/",
+                            id: "examplesdir",
+                            :create => true,
+                            type: "virtualbox")
+    config.vm.synced_folder("glyphs/", "/home/vagrant/apps/ledger-app-ark/glyphs/",
+                            id: "glyphsdir",
+                            :create => true,
+                            type: "virtualbox")
+    config.vm.synced_folder("src/", "/home/vagrant/apps/ledger-app-ark/src/",
+                            id: "srcdir",
+                            :create => true,
+                            type: "virtualbox")
+
+    # copy the rebuild script and app Makefile to vagrant machine
+    config.vm.provision("file",
+                        source: "./rebuild.sh",
+                        destination: "/home/vagrant/apps/ledger-app-ark/")
+    config.vm.provision("file",
+                        source: "./Makefile",
+                        destination: "/home/vagrant/apps/ledger-app-ark/")
+
+    # VM specific configs
+    config.vm.provider "virtualbox" do |v|
+        v.name = "Ledger Development Box"
+        v.customize ["modifyvm", :id, "--memory", "1024"]
+
+        # Connect Ledger Nano S throug usb
+        v.customize ["modifyvm", :id, "--usb", "on"]
+        v.customize ["modifyvm", :id, "--usbehci", "on"]
+        v.customize ["usbfilter", "add", "0",
+                     "--target", :id,
+                     "--name", "Ledger Nano S",
+                     "--manufacturer", "Ledger",
+                     "--product", "Nano S"]
+    end
+
+    # Shell provisioning
+    config.vm.provision "shell" do |s|
+        s.path = "provision/setup.sh"
+    end
+end

--- a/provision/setup.sh
+++ b/provision/setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+echo "Provisioning virtual machine..."
+
+echo "Installing Utilities"
+dpkg --add-architecture i386
+apt-get update  > /dev/null
+apt-get install git curl python-dev python-pip python-pil python-setuptools zlib1g-dev libjpeg-dev libudev-dev build-essential libusb-1.0-0-dev -y > /dev/null
+apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386 libc6-dev-i386 -y > /dev/null
+pip install --upgrade setuptools
+pip install ledgerblue
+
+if [ ! -d "/opt/bolos" ]; then
+    echo "Setting up BOLOS environment"
+    mkdir /opt/bolos
+    cd /opt/bolos
+fi
+
+if [ ! -d "/opt/bolos/gcc-arm-none-eabi-5_3-2016q1" ]; then
+    echo "Installing ARM compilers, this will take a few minutes..."
+    wget -q https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
+    tar xjf gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
+    ln -s /opt/bolos/gcc-arm-none-eabi-5_3-2016q1/bin/arm-none-eabi-gcc /usr/bin/arm-none-eabi-gcc
+fi
+
+if [ ! -d "/opt/bolos/clang-arm-fropi" ]; then
+    echo "Installing Clang compilers, this will take a few minutes..."
+    wget -q https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    tar xvf clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    mv clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04 clang-arm-fropi
+    chmod 757 -R clang-arm-fropi/
+    chmod +x clang-arm-fropi/bin/clang
+    ln -s /opt/bolos/clang-arm-fropi/bin/clang /usr/bin/clang
+fi
+
+if [ ! -d "/opt/bolos/nanos-secure-sdk" ]; then
+    echo "Fetching the Nano S SDK"
+    cd /opt/bolos/
+    git clone https://github.com/LedgerHQ/nanos-secure-sdk.git
+    cd nanos-secure-sdk/
+    git -c advice.detachedHead=false checkout tags/nanos-1553
+    cd /opt/bolos/
+fi
+
+echo "Finetuning rights for USB access"
+sudo bash /vagrant/provision/udev.sh
+usermod -a -G plugdev vagrant
+
+echo "Setting up bash profile"
+echo "" >> /home/vagrant/.bashrc
+echo "# Custom variables for Ledger Development" >> /home/vagrant/.bashrc
+echo "export BOLOS_ENV=/opt/bolos" >> /home/vagrant/.bashrc
+echo "export BOLOS_SDK=/opt/bolos/nanos-secure-sdk" >> /home/vagrant/.bashrc
+echo "export ARM_HOME=/opt/bolos/gcc-arm-none-eabi-5_3-2016q1" >> /home/vagrant/.bashrc
+echo "" >> /home/vagrant/.bashrc
+echo "export PATH=\$PATH:\$ARM_HOME/bin" >> /home/vagrant/.bashrc

--- a/provision/udev.sh
+++ b/provision/udev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+cat <<EOF > /etc/udev/rules.d/20-hw1.rules
+# HW.1 / Nano
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl"
+# Blue
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000|0000|0001|0002|0003|0004|0005|0006|0007|0008|0009|000a|000b|000c|000d|000e|000f|0010|0011|0012|0013|0014|0015|0016|0017|0018|0019|001a|001b|001c|001d|001e|001f", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
+# Nano S
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001|1000|1001|1002|1003|1004|1005|1006|1007|1008|1009|100a|100b|100c|100d|100e|100f|1010|1011|1012|1013|1014|1015|1016|1017|1018|1019|101a|101b|101c|101d|101e|101f", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
+# Aramis
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0002|2000|2001|2002|2003|2004|2005|2006|2007|2008|2009|200a|200b|200c|200d|200e|200f|2010|2011|2012|2013|2014|2015|2016|2017|2018|2019|201a|201b|201c|201d|201e|201f", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
+# HW2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0003|3000|3001|3002|3003|3004|3005|3006|3007|3008|3009|300a|300b|300c|300d|300e|300f|3010|3011|3012|3013|3014|3015|3016|3017|3018|3019|301a|301b|301c|301d|301e|301f", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
+# Nano X
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004|4000|4001|4002|4003|4004|4005|4006|4007|4008|4009|400a|400b|400c|400d|400e|400f|4010|4011|4012|4013|4014|4015|4016|4017|4018|4019|401a|401b|401c|401d|401e|401f", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
+EOF
+
+udevadm trigger
+udevadm control --reload-rules


### PR DESCRIPTION

## Summary

This PR adds Vagrant as a build option and expands the documentation to cover various topics.

Specifically, this PR does the following.
-   adds Vagrant file.
-   adds Vagrant provisioning files.
-   adds detailed steps and resources to the README.
-   updates the changelog.

## Checklist

- [x] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
