### PR TITLE
ci: fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,6 @@ jobs:
           cd nanos-secure-sdk/
           git -c advice.detachedHead=false checkout tags/nanos-1553
 
-          sudo bash ~/work/ledger/ledger/provision/udev.sh
-          sudo usermod --append --groups lxd $(whoami)
-          sudo usermod -a -G plugdev $(whoami)
-
       - name: Building the Ledger ARK app
         run: make
         env:


### PR DESCRIPTION
## Summary

Missed dropping the call to udev.sh, which is not needed for CI.

passing workflow here:

- [sleepdefic1t/ledger/commit/27e69...0b491/checks](https://github.com/sleepdefic1t/ledger/commit/27e69c27846e416922235ba84924ebe6e560b491/checks?check_suite_id=264939058)

## Checklist

- [x] Ready to be merged
