### PR TITLE
chore: pass size_t for buffers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "files.associations": {
+        "__hash_table": "c",
+        "__split_buffer": "c",
+        "array": "c",
+        "bitset": "c",
+        "deque": "c",
+        "string_view": "c",
+        "initializer_list": "c",
+        "iterator": "c",
+        "queue": "c",
+        "random": "c",
+        "string": "c",
+        "unordered_map": "c",
+        "utility": "c",
+        "vector": "c",
+        "hashtable": "c",
+        "__locale": "c",
+        "__string": "c"
+    }
+}

--- a/docs/unimplemented/type_2/type_2.c
+++ b/docs/unimplemented/type_2/type_2.c
@@ -84,7 +84,7 @@ static StreamStatus internalDeserializeAsset(Transaction *transaction,
         status = deserializeDelegateRegistration(
                         &transaction->asset.delegateRegistration,
                         &buffer[assetOffset],
-                        assetLength);
+                        assetSize);
         break;
 /////////
 }

--- a/docs/unimplemented/type_4/type_4.c
+++ b/docs/unimplemented/type_4/type_4.c
@@ -86,7 +86,7 @@ static StreamStatus internalDeserializeAsset(Transaction *transaction,
     case TRANSACTION_TYPE_MULTI_SIGNATURE:
         status = deserializeMultiSignature(&transaction->asset.multiSignature,
                                             &buffer[assetOffset],
-                                            assetLength);
+                                            assetSize);
         break;
 /////////
 }

--- a/docs/unimplemented/type_6/type_6.c
+++ b/docs/unimplemented/type_6/type_6.c
@@ -91,7 +91,7 @@ static StreamStatus internalDeserializeAsset(Transaction *transaction,
     case TRANSACTION_TYPE_MULTIPAYMENT:
         status = deserializeMultiPayment(&transaction->asset.multiPayment,
                                          &buffer[assetOffset],
-                                         assetLength);
+                                         assetSize);
         break;
 /////////
 }

--- a/src/crypto/hashing.c
+++ b/src/crypto/hashing.c
@@ -18,6 +18,7 @@
 
 #include "crypto/hashing.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -26,20 +27,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Generate a Ripemd160 hash
-void hash160(uint8_t WIDE *in, uint16_t inLength, uint8_t *out) {
+void hash160(uint8_t WIDE *in, size_t inSize, uint8_t *out) {
     cx_ripemd160_t ripeHash;
     cx_ripemd160_init(&ripeHash);
-    cx_hash(&ripeHash.header, CX_LAST, in, inLength, out, CX_SHA256_SIZE);
+    cx_hash(&ripeHash.header, CX_LAST, in, inSize, out, CX_SHA256_SIZE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void hash256(cx_sha256_t *ctx,
              uint8_t WIDE *in,
-             uint16_t inLength,
+             size_t inSize,
              uint8_t *out) {
     cx_sha256_init(ctx);
-    cx_hash(&ctx->header, CX_LAST, in, inLength, out, CX_SHA256_SIZE);
+    cx_hash(&ctx->header, CX_LAST, in, inSize, out, CX_SHA256_SIZE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/crypto/hashing.h
+++ b/src/crypto/hashing.h
@@ -19,6 +19,7 @@
 #ifndef ARK_CRYPTO_HASHING_H
 #define ARK_CRYPTO_HASHING_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -26,12 +27,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void hash160(uint8_t WIDE *in, uint16_t inLength, uint8_t *out);
+void hash160(uint8_t WIDE *in, size_t inSize, uint8_t *out);
 
-void hash256(cx_sha256_t *ctx,
-             uint8_t WIDE *in,
-             uint16_t inLength,
-             uint8_t *out);
+void hash256(cx_sha256_t *ctx, uint8_t WIDE *in, size_t inSize, uint8_t *out);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/crypto/keys.c
+++ b/src/crypto/keys.c
@@ -18,6 +18,8 @@
 
 #include "crypto/keys.h"
 
+#include <stddef.h>
+
 #include <os.h>
 #include <cx.h>
 
@@ -27,8 +29,8 @@
 
 void compressPublicKey(const cx_ecfp_public_key_t *publicKey,
                        uint8_t *out,
-                       uint8_t outLength) {
-    if (outLength != PUBLICKEY_COMPRESSED_LENGTH) {
+                       size_t outSize) {
+    if (outSize != PUBLICKEY_COMPRESSED_LENGTH) {
         THROW(EXCEPTION_OVERFLOW);
     }
 

--- a/src/crypto/keys.h
+++ b/src/crypto/keys.h
@@ -40,7 +40,7 @@ typedef struct public_key_context_t {
 
 void compressPublicKey(const cx_ecfp_public_key_t *publicKey,
                        uint8_t *out,
-                       uint8_t outLength);
+                       size_t outSize);
 
 uint32_t setPublicKeyContext(PublicKeyContext *ctx, uint8_t *apduBuffer);
 

--- a/src/crypto/signing.c
+++ b/src/crypto/signing.c
@@ -18,6 +18,8 @@
 
 #include "crypto/signing.h"
 
+#include <stddef.h>
+
 #include <os.h>
 #include <cx.h>
 
@@ -28,12 +30,12 @@
 uint32_t signEcdsa(const cx_ecfp_private_key_t *privateKey,
                    const uint8_t *hash,
                    uint8_t *signature,
-                   unsigned int signatureLength) {
+                   size_t signatureSize) {
     #if CX_APILEVEL >= 8U
         return cx_ecdsa_sign(privateKey,
                              CX_RND_RFC6979 | CX_LAST, CX_SHA256,
                              hash, HASH_32_LENGTH,
-                             signature, signatureLength,
+                             signature, signatureSize,
                              NULL);
     #else
         UNUSED(signatureLength);

--- a/src/crypto/signing.h
+++ b/src/crypto/signing.h
@@ -19,6 +19,7 @@
 #ifndef ARK_CRYPTO_SIGNING_H
 #define ARK_CRYPTO_SIGNING_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -41,7 +42,7 @@ typedef struct signing_context_t {
 uint32_t signEcdsa(const cx_ecfp_private_key_t *privateKey,
                    const uint8_t *hash,
                    uint8_t *signature,
-                   unsigned int signatureLength);
+                   size_t signatureSize);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transaction_op.h
+++ b/src/operations/transaction_op.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_H
 #define ARK_OPERATIONS_TRANSACTION_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -29,8 +30,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void handleTransaction(const uint8_t *buffer, uint32_t length) {
-    if (deserialize(buffer, length) != USTREAM_FINISHED) {
+void handleTransaction(const uint8_t *buffer, size_t size) {
+    if (deserialize(buffer, size) != USTREAM_FINISHED) {
         // Deserialization failed
         THROW(0x6A80);
     }

--- a/src/operations/transactions/assets/type_0.c
+++ b/src/operations/transactions/assets/type_0.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_0.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -34,7 +35,7 @@
 //
 // @param Transfer *transfer: The Transfer (Type 0) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -51,12 +52,12 @@
 // ---
 StreamStatus deserializeTransfer(Transfer *transfer,
                                  const uint8_t *buffer,
-                                 uint32_t length) {
-    if (length != 33U) {
+                                 size_t size) {
+    if (size != 33) {
         return USTREAM_FAULT;
     }
 
-    transfer->amount        = U8LE(buffer, 0U);
+    transfer->amount        = U8LE(buffer, 0);
     transfer->expiration    = U4LE(buffer, sizeof(uint64_t));
     os_memmove(transfer->recipient,
                &buffer[sizeof(uint64_t) + sizeof(uint32_t)],

--- a/src/operations/transactions/assets/type_0.h
+++ b/src/operations/transactions/assets/type_0.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_0_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_0_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -37,7 +38,7 @@ typedef struct transfer_asset_t {
 
 StreamStatus deserializeTransfer(Transfer *transfer,
                                  const uint8_t *buffer,
-                                 uint32_t length);
+                                 size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_1.c
+++ b/src/operations/transactions/assets/type_1.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_1.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -30,7 +31,7 @@
 //
 // @param SecondSignatureRegistration *registration: The Second Signature Registration (Type 1) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -41,8 +42,8 @@
 // ---
 StreamStatus deserializeSecondSignature(SecondSignatureRegistration *registration,
                                         const uint8_t *buffer,
-                                        uint32_t length) {
-    if (length != 33U) {
+                                        size_t size) {
+    if (size != 33) {
         return USTREAM_FAULT;
     }
 

--- a/src/operations/transactions/assets/type_1.h
+++ b/src/operations/transactions/assets/type_1.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_1_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_1_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -35,7 +36,7 @@ typedef struct ss_registration_asset_t {
 
 StreamStatus deserializeSecondSignature(SecondSignatureRegistration *registration,
                                         const uint8_t *buffer,
-                                        uint32_t length);
+                                        size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_10.c
+++ b/src/operations/transactions/assets/type_10.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_10.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -32,7 +33,7 @@
 //
 // @param HtlcRefund *refund: The Htlc Refund (Type 10) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -43,8 +44,8 @@
 // ---
 StreamStatus deserializeHtlcRefund(HtlcRefund *refund,
                                    const uint8_t *buffer,
-                                   uint32_t length) {
-    if (length != HASH_32_LENGTH) {
+                                   size_t size) {
+    if (size != HASH_32_LENGTH) {
         return USTREAM_FAULT;
     }
 

--- a/src/operations/transactions/assets/type_10.h
+++ b/src/operations/transactions/assets/type_10.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_10_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_10_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -35,7 +36,7 @@ typedef struct htlc_refund_asset_t {
 
 StreamStatus deserializeHtlcRefund(HtlcRefund *refund,
                                    const uint8_t *buffer,
-                                   uint32_t length);
+                                   size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_3.c
+++ b/src/operations/transactions/assets/type_3.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_3.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -32,7 +33,7 @@
 //
 // @param Vote *vote: The Vote (Type 3) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -44,10 +45,8 @@
 // - os_memmove(vote->data, &buffer[1], 1U + PUBLICKEY_COMPRESSED_LENGTH)
 //
 // ---
-StreamStatus deserializeVote(Vote *vote,
-                             const uint8_t *buffer,
-                             uint32_t length) {
-    if (length != 35U) {
+StreamStatus deserializeVote(Vote *vote, const uint8_t *buffer, size_t size) {
+    if (size != 35) {
         return USTREAM_FAULT;
     }
 

--- a/src/operations/transactions/assets/type_3.h
+++ b/src/operations/transactions/assets/type_3.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_3_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_3_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -33,9 +34,7 @@ typedef struct vote_asset_t {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-StreamStatus deserializeVote(Vote *vote,
-                             const uint8_t *buffer,
-                             uint32_t length);
+StreamStatus deserializeVote(Vote *vote, const uint8_t *buffer, size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_5.c
+++ b/src/operations/transactions/assets/type_5.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_5.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -32,7 +33,7 @@
 //
 // @param Ipfs *ipfs: The Ipfs (Type 5) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -46,7 +47,7 @@
 // ---
 StreamStatus deserializeIpfs(Ipfs *ipfs,
                              const uint8_t *buffer,
-                             uint32_t length) {
+                             size_t size) {
     // 2nd byte of IPFS hash contains its len.
     //
     // byte[0] == hash-type (sha256).
@@ -56,11 +57,11 @@ StreamStatus deserializeIpfs(Ipfs *ipfs,
 
     // Let's make sure the length isn't > 255,
     // and that the lengths match.
-    if (length > 255U || length != ipfs->length) {
+    if (size > 255 || size != ipfs->length) {
         return USTREAM_FAULT;
     }
 
-    os_memmove(ipfs->dag, buffer, length);
+    os_memmove(ipfs->dag, buffer, size);
 
     return USTREAM_FINISHED;
 }

--- a/src/operations/transactions/assets/type_5.h
+++ b/src/operations/transactions/assets/type_5.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_5_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_5_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -28,13 +29,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef struct ipfs_asset_t {
-  uint8_t   length;
+  size_t    length;
   uint8_t   dag[HASH_64_LENGTH];
 } Ipfs;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-StreamStatus deserializeIpfs(Ipfs *ipfs, const uint8_t *buffer, uint32_t length);
+StreamStatus deserializeIpfs(Ipfs *ipfs, const uint8_t *buffer, size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_8.c
+++ b/src/operations/transactions/assets/type_8.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_8.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -34,7 +35,7 @@
 //
 // @param HtlcLock *lock: The Htlc Lock (Type 8) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -57,15 +58,15 @@
 // ---
 StreamStatus deserializeHtlcLock(HtlcLock *lock,
                                  const uint8_t *buffer,
-                                 uint32_t length) {
-    if (length != 66U) {
+                                 size_t size) {
+    if (size != 66) {
         return USTREAM_FAULT;
     }
 
-    lock->amount            = U8LE(buffer, 0U);
+    lock->amount            = U8LE(buffer, 0);
     os_memmove(lock->secretHash, &buffer[8], HASH_32_LENGTH);
     lock->expirationType    = buffer[40];
-    lock->expiration        = U4LE(buffer, 41U);
+    lock->expiration        = U4LE(buffer, 41);
     os_memmove(lock->recipient, &buffer[45], ADDRESS_HASH_LENGTH);
 
     return USTREAM_FINISHED;

--- a/src/operations/transactions/assets/type_8.h
+++ b/src/operations/transactions/assets/type_8.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_8_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_8_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -39,7 +40,7 @@ typedef struct htlc_lock_asset_t {
 
 StreamStatus deserializeHtlcLock(HtlcLock *lock,
                                  const uint8_t *buffer,
-                                 uint32_t length);
+                                 size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/assets/type_9.c
+++ b/src/operations/transactions/assets/type_9.c
@@ -18,6 +18,7 @@
 
 #include "transactions/assets/type_9.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -35,7 +36,7 @@
 //
 // @param HtlcClaim *claim: The Htlc Claim (Type 8) Asset.
 // @param uint8_t *buffer: The serialized buffer beginning at the Assets offset.
-// @param uint32_t length: The Asset Length.
+// @param size_t size: The Asset Buffer Size.
 //
 // ---
 // Internals:
@@ -49,13 +50,13 @@
 // ---
 StreamStatus deserializeHtlcClaim(HtlcClaim *claim,
                                   const uint8_t *buffer,
-                                  uint32_t length) {
-    if (length <= HASH_32_LENGTH) {
+                                  size_t size) {
+    if (size <= HASH_32_LENGTH) {
         return USTREAM_FAULT;
     }
 
     os_memmove(claim->id, &buffer[0], HASH_32_LENGTH);
-    os_memmove(claim->secret, &buffer[HASH_32_LENGTH], length - HASH_32_LENGTH);
+    os_memmove(claim->secret, &buffer[HASH_32_LENGTH], size - HASH_32_LENGTH);
 
     return USTREAM_FINISHED;
 }

--- a/src/operations/transactions/assets/type_9.h
+++ b/src/operations/transactions/assets/type_9.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTION_TYPE_9_H
 #define ARK_OPERATIONS_TRANSACTION_TYPE_9_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -36,7 +37,7 @@ typedef struct htlc_claim_asset_t {
 
 StreamStatus deserializeHtlcClaim(HtlcClaim *claim,
                                   const uint8_t *buffer,
-                                  uint32_t length);
+                                  size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/deserializer.h
+++ b/src/operations/transactions/deserializer.h
@@ -19,13 +19,14 @@
 #ifndef ARK_OPERATIONS_TRANSACTIONS_DESERIALIZER_H
 #define ARK_OPERATIONS_TRANSACTIONS_DESERIALIZER_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "operations/status.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
-StreamStatus deserialize(const uint8_t *buffer, uint32_t length);
+StreamStatus deserialize(const uint8_t *buffer, size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/legacy/deserialize_legacy.c
+++ b/src/operations/transactions/legacy/deserialize_legacy.c
@@ -18,6 +18,7 @@
 
 #include "transactions/legacy/deserialize_legacy.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "constants.h"
@@ -32,7 +33,7 @@
 
 StreamStatus deserializeLegacy(Transaction *transaction,
                                const uint8_t *buffer,
-                               uint32_t length) {
+                               size_t size) {
     // V1
     if (buffer[0] == 0xFF) {
         // Deserialize Common
@@ -45,11 +46,11 @@ StreamStatus deserializeLegacy(Transaction *transaction,
         transaction->vendorField        = (uint8_t *)&buffer[50];
 
         transaction->assetOffset        = (49U + buffer[49U] + 1U);
-        transaction->assetLength        = length - (transaction->assetOffset);
+        transaction->assetSize          = size - (transaction->assetOffset);
 
         // Type 0: Transfer
         if (transaction->type == 0U) {
-            if (transaction->assetLength != 33U) {
+            if (transaction->assetSize != 33) {
                 return USTREAM_FAULT;
             }
 
@@ -62,7 +63,7 @@ StreamStatus deserializeLegacy(Transaction *transaction,
         }
         // Type 3: Vote
         else if (transaction->type == 3U) { 
-            if (transaction->assetLength != 35U) {
+            if (transaction->assetSize != 35) {
                 return USTREAM_FAULT;
             }
         }
@@ -92,22 +93,22 @@ StreamStatus deserializeLegacy(Transaction *transaction,
             transaction->vendorFieldLength = 0U;
         }
 
-        transaction->amount         = U8LE(buffer, 123U);
-        transaction->fee            = U8LE(buffer, 131U);
+        transaction->amount         = U8LE(buffer, 123);
+        transaction->fee            = U8LE(buffer, 131);
 
-        transaction->assetOffset    = 139U;
-        transaction->assetLength    = length - transaction->assetOffset;
+        transaction->assetOffset    = 139;
+        transaction->assetSize      = size - transaction->assetOffset;
 
         // Type 0: Transfer
         if (transaction->type == 0U) {
-            if (transaction->assetLength != 0U) {
+            if (transaction->assetSize != 0U) {
                 return USTREAM_FAULT;
             }
         }
 
         // Type 3: Vote
         else if (transaction->type == 3U){
-            if (transaction->assetLength != 67U) {
+            if (transaction->assetSize != 67) {
                 return USTREAM_FAULT;
             }
         }

--- a/src/operations/transactions/legacy/deserialize_legacy.h
+++ b/src/operations/transactions/legacy/deserialize_legacy.h
@@ -19,6 +19,7 @@
 #ifndef ARK_OPERATIONS_TRANSACTIONS_DESERIALIZE_LEGACY_H
 #define ARK_OPERATIONS_TRANSACTIONS_DESERIALIZE_LEGACY_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "operations/status.h"
@@ -28,7 +29,7 @@
 
 StreamStatus deserializeLegacy(Transaction *transaction,
                                const uint8_t *buffer,
-                               uint32_t length);
+                               size_t size);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/operations/transactions/transaction.h
+++ b/src/operations/transactions/transaction.h
@@ -39,8 +39,8 @@ typedef struct transaction_t {
         struct {  // v1 or Legacy
             uint8_t     recipient[ADDRESS_HASH_LENGTH];
             uint64_t    amount;
-            uint32_t    assetOffset;
-            uint8_t     assetLength;
+            size_t      assetOffset;
+            size_t      assetSize;
             uint8_t     *assetPtr;
         };
         struct {  // v2

--- a/src/utils/base58.h
+++ b/src/utils/base58.h
@@ -19,6 +19,7 @@
 #ifndef ARK_UTILS_BASE58_H
 #define ARK_UTILS_BASE58_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -26,14 +27,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 uint8_t encodeBase58(uint8_t WIDE *in,
-                     uint8_t length,
+                     size_t inSize,
                      uint8_t *out,
-                     uint8_t maxoutlen);
+                     size_t maxOutSize);
 
 uint16_t encodeBase58PublicKey(uint8_t WIDE *in,
-                               uint16_t inLength,
+                               size_t inSize,
                                uint8_t *out,
-                               uint16_t outLength,
+                               size_t outSize,
                                uint16_t version,
                                uint8_t alreadyHashed);
 

--- a/src/utils/hex.c
+++ b/src/utils/hex.c
@@ -18,6 +18,7 @@
 
 #include "utils/hex.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <os.h>
@@ -33,7 +34,7 @@ const uint8_t hexDigits[] = {
 
 // Convert Bytes to a Hex string.
 // NULL terminator is added at (hexStringLen + 1)
-void bytesToHex(char *dest, const uint8_t *src, uint8_t length) {
+void bytesToHex(char *dest, const uint8_t *src, size_t length) {
     while (length--) {
         *dest++ = hexDigits[(*src >> 0x04) & 0xF];
         *dest++ = hexDigits[*src & 0xF];

--- a/src/utils/hex.h
+++ b/src/utils/hex.h
@@ -19,11 +19,12 @@
 #ifndef ARK_UTILS_HEX_H
 #define ARK_UTILS_HEX_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void bytesToHex(char *dest, const uint8_t *src, uint8_t length);
+void bytesToHex(char *dest, const uint8_t *src, size_t length);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/utils/print.h
+++ b/src/utils/print.h
@@ -19,16 +19,17 @@
 #ifndef ARK_UTILS_PRINT_H
 #define ARK_UTILS_PRINT_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
-uint8_t printAmount(uint64_t amount,
-                    uint8_t *out,
-                    uint8_t outLength,
-                    const char *tokenName,
-                    uint8_t tokenNameLength,
-                    uint8_t decimals);
+size_t printAmount(uint64_t amount,
+                   uint8_t *out,
+                   size_t outSize,
+                   const char *tokenName,
+                   size_t tokenNameSize,
+                   uint8_t decimals);
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Summary

Use `size_t` when passing the size of buffers.
Improves readability, make intent more clear, improves portability and type-safety.

## Checklist

- [x] Ready to be merged
