### PR TITLE
chore: update the publicKey request call

### DIFF
--- a/examples/example_helper.py
+++ b/examples/example_helper.py
@@ -79,7 +79,7 @@ args = parser.parse_args()
 
 # Use default path if not provided.
 if args.path is None:
-    args.path="44'/111'/0'/0/0"
+    args.path = "44'/1'/0'/0/0"
 
 
 # Check that one and only one payload operation is called.

--- a/src/approval.c
+++ b/src/approval.c
@@ -71,8 +71,9 @@ unsigned int ioApprove(const bagl_element_t *e) {
     explicit_bzero(&displayCtx, sizeof(displayCtx));
 
     uint32_t tx = 0;
-    cx_ecfp_private_key_t privateKey;
-    uint8_t privateKeyData[HASH_64_LEN];
+
+    uint8_t                 privateKeyData[HASH_32_LEN];
+    cx_ecfp_private_key_t   privateKey;
 
     os_perso_derive_node_bip32(CX_CURVE_256K1,
                                tmpCtx.signing.bip32Path,
@@ -87,8 +88,6 @@ unsigned int ioApprove(const bagl_element_t *e) {
 
     explicit_bzero(privateKeyData, sizeof(privateKeyData));
 
-    setPublicKeyContext(&tmpCtx.publicKey, G_io_apdu_buffer);
-
     if (tmpCtx.signing.curve == CX_CURVE_256K1) {
         uint8_t hash[CX_SHA256_SIZE];
         hash256(tmpCtx.signing.data,
@@ -101,6 +100,7 @@ unsigned int ioApprove(const bagl_element_t *e) {
     }
 
     explicit_bzero(&privateKey, sizeof(privateKey));
+    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
 
     G_io_apdu_buffer[tx++] = 0x90;
     G_io_apdu_buffer[tx++] = 0x00;
@@ -118,6 +118,7 @@ unsigned int ioApprove(const bagl_element_t *e) {
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int ioCancel(const bagl_element_t *e) {
     explicit_bzero(&displayCtx, sizeof(displayCtx));
+    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
 
     G_io_apdu_buffer[0] = 0x69;
     G_io_apdu_buffer[1] = 0x85;
@@ -134,6 +135,9 @@ unsigned int ioCancel(const bagl_element_t *e) {
 
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int ioExit(const bagl_element_t *e) {
+    explicit_bzero(&displayCtx, sizeof(displayCtx));
+    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
+
     // Go back to the dashboard
     os_sched_exit(0);
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -47,6 +47,7 @@ static const size_t ADDRESS_LEN                     = 34;
 static const size_t ADDRESS_HASH_LEN                = 21;
 static const size_t ADDRESS_MAX_BIP32_PATH          = 10;
 static const size_t PUBLICKEY_COMPRESSED_LEN        = 33;
+static const size_t PUBLICKEY_UNCOMPRESSED_LEN      = 65;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Labels

--- a/src/crypto/keys.h
+++ b/src/crypto/keys.h
@@ -31,23 +31,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <os.h>
-
 #include "constants.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 typedef struct public_key_context_t {
-    cx_ecfp_public_key_t    data;
-    uint8_t                 address[41];
-    uint8_t                 chainCode[HASH_32_LEN];
-    bool                    needsChainCode;
+    uint8_t     data[PUBLICKEY_UNCOMPRESSED_LEN];
+    uint8_t     chainCode[HASH_32_LEN];
+    bool        needsChainCode;
 } PublicKeyContext;
 
 ////////////////////////////////////////////////////////////////////////////////
-void compressPublicKey(const cx_ecfp_public_key_t *publicKey,
-                       uint8_t *out,
-                       size_t outSize);
-
-uint32_t setPublicKeyContext(PublicKeyContext *ctx, uint8_t *apduBuffer);
+size_t compressPublicKey(const uint8_t *uncompressed, uint8_t *compressed);
 
 #endif  // #define ARK_CRYPTO_KEYS_H


### PR DESCRIPTION
## Summary

The ARK Ledger App has always appended a UTF8-encoded address to the PublicKey request operations' return value.

This is not correct or needed because:
1) ARK addresses are always passed as a serialized 21-byte-array internally.
2) Wallets create Ledger addresses from the returned publicKey.
3) There was never a means to specify the network byte when creating an address.

This PR proposes returning only the publicKey len and publicKey from the PublicKey request logic.
(e.g. (0x21(33) + publicKey))

Specifically, the following is suggested:
- drop `cx_ecfp_public_key_t` from PublicKeyContext in favor of a raw byte buffer.
- create a constant for the Uncompressed PublicKey len.
- remove the `setPublicKeyContext` method.
- factor out `setPublicKeyContext` from the approval flow.
- add calls to clear sensitive values from the approval flow.
- factor out `setPublicKeyContext` from `handlePublicKeyContext`.
- simplify the `compressPublicKey` method by removing Ledger SDK code and operating on the raw bytes.
- add more checks to the `compressPublicKey` method.
- add minor formatting updates to the touched files.
- update the default path in the `example_helper.py` script ("44'/111'/0'/0/0" -> "44'/1'/0'/0/0").

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

## Additional Comments

These changes are non-breaking and help to further decouple Ledger SDK-dependent code from the implementation.
