### PR TITLE
chore: improve print methods

### DIFF
--- a/docs/unsupported/delegate_registration/delegate_registration_ux.c
+++ b/docs/unsupported/delegate_registration/delegate_registration_ux.c
@@ -66,8 +66,8 @@ void displayDelegateRegistration(const Transaction *transaction) {
             transaction->asset.delegateRegistration.length);
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[1],
-                sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }

--- a/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
+++ b/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
@@ -67,7 +67,8 @@ void displayDelegateResignation(const Transaction *transaction) {
                PUBLICKEY_COMPRESSED_LEN);
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[1], sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }

--- a/docs/unsupported/multi_signature/multi_signature_ux.c
+++ b/docs/unsupported/multi_signature/multi_signature_ux.c
@@ -63,12 +63,12 @@ void displayMultiSignature(const Transaction *transaction) {
     bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Key Count
-    printAmount(transaction->asset.multiSignature.count,
-                (uint8_t *)displayCtx.text[0], sizeof(displayCtx.text[0]),
-                "", 0, 0);
+    UintToString(transaction->asset.multiSignature.count,
+                 (char *)displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[1], sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -64,7 +64,16 @@ static const char *const LABEL_TO       = "To";
 static const size_t LABEL_TO_SIZE       = 3;
 
 ////////////////////////////////////////////////////////////////////////////////
+// Numbers
+static const uint64_t UINT64_BASE_10 = 10U;
+
+////////////////////////////////////////////////////////////////////////////////
+// Strings
+static const size_t UINT64_MAX_STRING_SIZE = 20U;
+
+////////////////////////////////////////////////////////////////////////////////
 // Token
+static const size_t TOKEN_AMOUNT_MAX_CHARS  = 25U;
 static const size_t TOKEN_DECIMALS          = 8;
 static const char *const TOKEN_NAME         = "ARK ";
 static const size_t TOKEN_NAME_SIZE         = 4;        // sizeof("ARK ") - 1

--- a/src/operations/message_op.h
+++ b/src/operations/message_op.h
@@ -71,10 +71,9 @@ bool handleMessage(const uint8_t *buffer, size_t length) {
     bytecpy((char *)displayCtx.extended_title, LABEL, LABEL_SIZE);
 
     // Message Length
-    printAmount(length,
-                displayCtx.text[0],
-                sizeof(displayCtx.text[0]),
-                "", 0U, 0U);
+    UintToString(length,
+                 (char *)displayCtx.text[0],
+                 sizeof(displayCtx.text[0]));
 
     // Message Text
     bytecpy((char *)displayCtx.extended_text, buffer, length);

--- a/src/operations/transactions/legacy/display_legacy.c
+++ b/src/operations/transactions/legacy/display_legacy.c
@@ -71,16 +71,16 @@ void setTransferLegacy(const Transaction *transaction) {
     displayCtx.text[0][ADDRESS_LEN]  = ' ';
 
     // Amount
-    printAmount(transaction->amount,
-                displayCtx.text[1],
-                sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->amount,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // Fee
-    printAmount(transaction->fee,
-                displayCtx.text[2],
-                sizeof(displayCtx.text[2]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[2], sizeof(displayCtx.text[2]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // VendorField
     if (transaction->vendorFieldLength > 0) {
@@ -97,12 +97,10 @@ static void setVoteLegacy(const Transaction *transaction) {
     const size_t voteOffset = 67;
     bytecpy((char*)displayCtx.text[0], transaction->assetPtr, voteOffset);
 
-    printAmount(transaction->fee,
-                displayCtx.text[1],
-                sizeof(displayCtx.text[1]),
-                TOKEN_NAME,
-                TOKEN_NAME_SIZE,
-                TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/operations/transactions/ux/htlc_lock_ux.c
+++ b/src/operations/transactions/ux/htlc_lock_ux.c
@@ -79,28 +79,33 @@ void displayHtlcLock(const Transaction *transaction) {
 
     // Secret Hash
     bytesToHex((char *)displayCtx.text[1],
-               (uint8_t *)transaction->asset.htlcLock.secretHash,
+               transaction->asset.htlcLock.secretHash,
                HASH_32_LEN);
 
     // Expiration
     if (transaction->asset.htlcLock.expirationType == 1U) {
-        printAmount(transaction->asset.htlcLock.expiration,
-                    displayCtx.text[2], sizeof(displayCtx.text[2]),
-                    LABEL_TIME, LABEL_TIME_SIZE, 0);
+        bytecpy(displayCtx.text[2], LABEL_TIME, LABEL_TIME_SIZE);
+        UintToString(transaction->asset.htlcLock.expiration,
+                     (char *)&displayCtx.text[2][LABEL_TIME_SIZE],
+                     sizeof(displayCtx.text[2]));
     } else {
-        printAmount(transaction->asset.htlcLock.expiration,
-                    displayCtx.text[2], sizeof(displayCtx.text[2]),
-                    LABEL_HEIGHT, LABEL_HEIGHT_SIZE, 0);
+        bytecpy(displayCtx.text[2], LABEL_HEIGHT, LABEL_HEIGHT_SIZE);
+        UintToString(transaction->asset.htlcLock.expiration,
+                     (char *)&displayCtx.text[2][LABEL_HEIGHT_SIZE],
+                     sizeof(displayCtx.text[2]));
     }
 
     // Amount
-    printAmount(transaction->asset.htlcLock.amount,
-                (uint8_t *)displayCtx.text[3], sizeof(displayCtx.text[3]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->asset.htlcLock.amount,
+                        (char *)displayCtx.text[3], sizeof(displayCtx.text[3]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
+
     // Fees
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[4], sizeof(displayCtx.text[4]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[4], sizeof(displayCtx.text[4]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // VendorField
     if (transaction->vendorFieldLength > 0U) {

--- a/src/operations/transactions/ux/ipfs_ux.c
+++ b/src/operations/transactions/ux/ipfs_ux.c
@@ -52,9 +52,10 @@ void displayIpfs(const Transaction *transaction) {
     bytecpy((char *)displayCtx.extended_title, LABEL_DAG, LABEL_DAG_SIZE);
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[0], sizeof(displayCtx.text[0]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[0], sizeof(displayCtx.text[0]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // DAG
     size_t dagLen = MAX_TEXT_LEN;

--- a/src/operations/transactions/ux/second_signature_ux.c
+++ b/src/operations/transactions/ux/second_signature_ux.c
@@ -53,11 +53,12 @@ void displaySecondSignature(const Transaction *transaction) {
 
     // PublicKey of Second Signature
     bytesToHex((char *)displayCtx.text[0],
-                transaction->asset.secondSignature.publicKey,
-                PUBLICKEY_COMPRESSED_LEN);
+               transaction->asset.secondSignature.publicKey,
+               PUBLICKEY_COMPRESSED_LEN);
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[1], sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }

--- a/src/operations/transactions/ux/transfer_ux.c
+++ b/src/operations/transactions/ux/transfer_ux.c
@@ -62,22 +62,20 @@ void displayTransfer(const Transaction *transaction) {
                           1U);
 
     // Expiration
-    printAmount(transaction->asset.transfer.expiration,
-                displayCtx.text[1],
-                sizeof(displayCtx.text[1]),
-                NULL, 0U, 0U);
+    UintToString(transaction->asset.transfer.expiration,
+                 (char *)displayCtx.text[1], sizeof(displayCtx.text[1]));
 
     // Amount
-    printAmount(transaction->asset.transfer.amount,
-                displayCtx.text[2],
-                sizeof(displayCtx.text[2]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->asset.transfer.amount,
+                        (char *)displayCtx.text[2], sizeof(displayCtx.text[2]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // Fee
-    printAmount(transaction->fee,
-                displayCtx.text[3],
-                sizeof(displayCtx.text[3]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[3], sizeof(displayCtx.text[3]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 
     // VendorField
     if (transaction->vendorFieldLength > 0U) {

--- a/src/operations/transactions/ux/vote_ux.c
+++ b/src/operations/transactions/ux/vote_ux.c
@@ -67,7 +67,8 @@ void displayVote(const Transaction *transaction) {
                 PUBLICKEY_COMPRESSED_LEN);
 
     // Fee
-    printAmount(transaction->fee,
-                (uint8_t *)displayCtx.text[1], sizeof(displayCtx.text[1]),
-                TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS);
+    TokenAmountToString(transaction->fee,
+                        (char *)displayCtx.text[1], sizeof(displayCtx.text[1]),
+                        TOKEN_NAME, TOKEN_NAME_SIZE,
+                        TOKEN_DECIMALS);
 }

--- a/src/utils/print.h
+++ b/src/utils/print.h
@@ -31,11 +31,12 @@
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-size_t printAmount(uint64_t amount,
-                   uint8_t *out,
-                   size_t outSize,
-                   const char *tokenName,
-                   size_t tokenNameSize,
-                   uint8_t decimals);
+size_t UintToString(uint64_t value, char *dst, size_t maxLen);
 
-#endif  // #ifndef ARK_UTILS_PRINT_H
+////////////////////////////////////////////////////////////////////////////////
+size_t TokenAmountToString(uint64_t amount,
+                           char *dst, size_t maxLen,
+                           const char *tokenName, size_t tokenNameSize,
+                           size_t decimals);
+
+#endif  // ARK_UTILS_PRINT_H


### PR DESCRIPTION

## Summary

The old implementation of 'printAmount' was kind of buggy, and num to string methods are starting to be relied on more.

The changes in this PR focus on extracting the 'printAmount' method to improving bounds-checking and type-enforcement, use more concise naming, and separate logic more cleanly.

## Checklist

- [x] Ready to be merged
