### PR TITLE
chore: improve hex implementation

### DIFF
--- a/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
+++ b/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
@@ -62,9 +62,8 @@ void displayDelegateResignation(const Transaction *transaction) {
     bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Delegate PublicKey
-    bytesToHex((char *)displayCtx.text[0],
-               transaction->senderPublicKey,
-               PUBLICKEY_COMPRESSED_LEN);
+    BytesToHex(transaction->senderPublicKey, PUBLICKEY_COMPRESSED_LEN,
+               displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
     TokenAmountToString(transaction->fee,

--- a/src/operations/transactions/ux/htlc_claim_ux.c
+++ b/src/operations/transactions/ux/htlc_claim_ux.c
@@ -54,9 +54,8 @@ void displayHtlcClaim(const Transaction *transaction) {
     bytecpy((char *)displayCtx.title[1], LABEL_SECRET, LABEL_SECRET_SIZE);
 
     // Id
-    bytesToHex((char *)displayCtx.text[0],
-               transaction->asset.htlcClaim.id,
-               HASH_32_LEN);
+    BytesToHex(transaction->asset.htlcClaim.id, HASH_32_LEN,
+               displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Secret
     bytecpy((char *)displayCtx.text[1],

--- a/src/operations/transactions/ux/htlc_lock_ux.c
+++ b/src/operations/transactions/ux/htlc_lock_ux.c
@@ -78,9 +78,8 @@ void displayHtlcLock(const Transaction *transaction) {
                           1);
 
     // Secret Hash
-    bytesToHex((char *)displayCtx.text[1],
-               transaction->asset.htlcLock.secretHash,
-               HASH_32_LEN);
+    BytesToHex(transaction->asset.htlcLock.secretHash, HASH_32_LEN,
+                displayCtx.text[1], sizeof(displayCtx.text[1]));
 
     // Expiration
     if (transaction->asset.htlcLock.expirationType == 1U) {

--- a/src/operations/transactions/ux/htlc_refund_ux.c
+++ b/src/operations/transactions/ux/htlc_refund_ux.c
@@ -50,7 +50,6 @@ void displayHtlcRefund(const Transaction *transaction) {
     bytecpy((char *)displayCtx.title[0], LABEL_LOCK_ID, LABEL_LOCK_ID_SIZE);
 
     // Lock Id
-    bytesToHex((char *)displayCtx.text[0],
-               transaction->asset.htlcRefund.id,
-               HASH_32_LEN);
+    BytesToHex(transaction->asset.htlcRefund.id, HASH_32_LEN,
+               displayCtx.text[0], sizeof(displayCtx.text[0]));
 }

--- a/src/operations/transactions/ux/second_signature_ux.c
+++ b/src/operations/transactions/ux/second_signature_ux.c
@@ -52,9 +52,9 @@ void displaySecondSignature(const Transaction *transaction) {
     bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // PublicKey of Second Signature
-    bytesToHex((char *)displayCtx.text[0],
-               transaction->asset.secondSignature.publicKey,
-               PUBLICKEY_COMPRESSED_LEN);
+    BytesToHex(transaction->asset.secondSignature.publicKey,
+               PUBLICKEY_COMPRESSED_LEN,
+               displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
     TokenAmountToString(transaction->fee,

--- a/src/operations/transactions/ux/vote_ux.c
+++ b/src/operations/transactions/ux/vote_ux.c
@@ -62,9 +62,8 @@ void displayVote(const Transaction *transaction) {
 
     // Vote
     displayCtx.text[0][0] = voteSymbol;
-    bytesToHex((char *)&displayCtx.text[0][1],
-                &transaction->asset.vote.data[1],
-                PUBLICKEY_COMPRESSED_LEN);
+    BytesToHex(&transaction->asset.vote.data[1], PUBLICKEY_COMPRESSED_LEN,
+               &displayCtx.text[0][1], sizeof(displayCtx.text[0]) - 1);
 
     // Fee
     TokenAmountToString(transaction->fee,

--- a/src/utils/hex.c
+++ b/src/utils/hex.c
@@ -30,19 +30,24 @@
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-static const uint8_t hexDigits[] = {
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-    'a', 'b', 'c', 'd', 'e', 'f'
-};
-
-////////////////////////////////////////////////////////////////////////////////
 // Convert Bytes to a Hex string.
-// NULL terminator is added at (hexStringLen + 1)
-void bytesToHex(char *dest, const uint8_t *src, size_t length) {
-    while (length--) {
-        *dest++ = hexDigits[(*src >> 4) & 0xF];
-        *dest++ = hexDigits[*src & 0xF];
-        ++src;
+// NULL terminated at (n + 1)
+size_t BytesToHex(const uint8_t *src, size_t srcLen, char *dst, size_t dstMax) {
+    if (src == NULL || dst == NULL || (srcLen * 2) + 1 > dstMax) {
+        return 0;
     }
-    *dest = '\0';
+
+    const char *const HEX_DIGITS = "0123456789abcdef";
+
+    size_t len = srcLen;
+
+    do {
+        *dst++ = HEX_DIGITS[(*src >> 4) & 0xF];
+        *dst++ = HEX_DIGITS[*src & 0xF];
+        ++src;
+    } while (len-- > 1);
+
+    *dst = '\0';
+
+    return (srcLen * 2) + 1;
 }

--- a/src/utils/hex.h
+++ b/src/utils/hex.h
@@ -31,6 +31,6 @@
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-void bytesToHex(char *dest, const uint8_t *src, size_t length);
+size_t BytesToHex(const uint8_t *src, size_t srcLen, char *dst, size_t dstMax);
 
-#endif  // #ifndef ARK_UTILS_HEX_H
+#endif  // ARK_UTILS_HEX_H


### PR DESCRIPTION

## Summary

- `bytesToHex` -> `BytesToHex`
- `BytesToHex` now returns size, or '0' if there's an error
- better type-safety and bounds-checking

## Checklist

- [x] Ready to be merged
