### PR TITLE
ci: add testing artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,19 @@ jobs:
           BOLOS_ENV: /opt/bolos
           BOLOS_SDK: /opt/bolos/nanos-secure-sdk
           ARM_HOME: /opt/bolos/gcc-arm-none-eabi-5_3-2016q1
+
+      - name: Preparing Artifacts 
+        run: |
+          mkdir ./.github/workflows/artifacts
+          cp ./bin/app.hex ./.github/workflows/artifacts/
+          cp ./examples/example_helper.py ./.github/workflows/artifacts/
+          printf '#!/usr/bin/env bash\n\n# Artifact builds are for TESTING PURPOSES ONLY!\n# Never use this with personal funds.\n#\n# unzip the artifacts and run "bash ./flash.sh" to execute this script.\n#\n# Requirements:\n# - python3\n# - ledgerblue (pip3 install ledgerblue)\n#\n' >> ./.github/workflows/artifacts/flash.sh && printf "%s" 'python3 -m ledgerblue.loadApp --fileName app.hex --appName Ark --appFlags 0x240 --curve secp256k1 --path ' "\"44'/111'\"" ' --path ' "\"44'/1'\"" ' --targetId 0x31100004 --targetVersion="1.6.0" --icon "010000000000ffffffffffffffffffffff7ffe3ffc1ff89ff98ff1cff347e267e6ffffffffffffffff" --tlv --delete' >> ./.github/workflows/artifacts/flash.sh && printf '\n' >> ./.github/workflows/artifacts/flash.sh
+          printf '#!/usr/bin/env bash\n\npython3 example_helper.py --publickey\n' >> ./.github/workflows/artifacts/publickey.sh
+          printf '#!/usr/bin/env bash\n\npython3 example_helper.py --message 416c6c2070617274732073686f756c6420676f20746f67657468657220776974686f757420666f7263696e672e20596f75206d7573742072656d656d62657220746861742074686520706172747320796f7520617265207265617373656d626c696e67207765726520646973617373656d626c656420627920796f752e205468657265666f72652c20696620796f752063616e277420676574207468656d20746f67657468657220616761696e2c207468657265206d757374206265206120726561736f6e2e20427920616c6c206d65616e732c20646f206e6f742075736520612068616d6d65722e207e2049424d204d616e75616c202d20283139373529\n' >> ./.github/workflows/artifacts/message.sh
+          printf '#!/usr/bin/env bash\n\npython3 example_helper.py --tx ff0217010000000000010000000000000003a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933809698000000000000a08601000000000000000000171dfc69b54c7fe901e91d5a9ab78388645e2427ea\n' >> ./.github/workflows/artifacts/transfer.sh
+
+      - name: Uploading Artifacts
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: app-artifact-${{ github.sha }}
+          path: ./.github/workflows/artifacts/*


### PR DESCRIPTION

## Summary

This basically makes it easier for others to test.

Currently, you'd need to spin up an entire Vagrant Machine and build from src.

Since the CI Workflow already builds the app,
we can just extract the 'app.hex' file to artifacts.

This allows anyone to flash the pre-built app to their device.

Also added is the following:
- `message.sh`: Test a message instruction.
- `publickey.sh`: Get a device publicKey.
- `transfer.sh`: Test a transfer instruction.
- `example_helper.py`: Helper to run the test scripts

## Checklist

- [x] Ready to be merged

## Additional Comments

An example of these artifacts can be seen here:
https://github.com/sleepdefic1t/ledger/actions/runs/62660289