### PR TITLE
chore: improve utils dir implementations

### DIFF
--- a/docs/unsupported/delegate_registration/delegate_registration.c
+++ b/docs/unsupported/delegate_registration/delegate_registration.c
@@ -57,7 +57,7 @@
 // - registration->length = buffer[0];
 //
 // Username - 3 <=> 20 Bytes:
-// - bytecpy(registration->username, &buffer[1], registration->length)
+// - MEMCOPY(registration->username, &buffer[1], registration->length)
 //
 // ---
 bool deserializeDelegateRegistration(DelegateRegistration *registration,
@@ -70,9 +70,9 @@ bool deserializeDelegateRegistration(DelegateRegistration *registration,
     }
 
     registration->length = (int)buffer[0];
-    bytecpy((void *)registration->username,
+    MEMCOPY(registration->username,
             &buffer[1],
-            (int)registration->length);
+            registration->length);
 
     return true;
 }

--- a/docs/unsupported/delegate_registration/delegate_registration_ux.c
+++ b/docs/unsupported/delegate_registration/delegate_registration_ux.c
@@ -56,12 +56,12 @@ void displayDelegateRegistration(const Transaction *transaction) {
     const char *const LABEL_USERNAME     = "Username";
     const size_t LABEL_USERNAME_SIZE     = 9;
 
-    bytecpy((char *)displayCtx.operation, LABEL, LABEL_SIZE);
-    bytecpy((char *)displayCtx.title[0], LABEL_USERNAME, LABEL_USERNAME_SIZE);
-    bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
+    MEMCOPY(displayCtx.operation, LABEL, LABEL_SIZE);
+    MEMCOPY(displayCtx.title[0], LABEL_USERNAME, LABEL_USERNAME_SIZE);
+    MEMCOPY(displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Username
-    bytecpy((char *)displayCtx.text[0],
+    MEMCOPY(displayCtx.text[0],
             transaction->asset.delegateRegistration.username,
             transaction->asset.delegateRegistration.length);
 

--- a/docs/unsupported/delegate_registration/delegate_registration_ux.c
+++ b/docs/unsupported/delegate_registration/delegate_registration_ux.c
@@ -42,7 +42,7 @@
 
 #include "operations/transactions/transaction.h"
 
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -66,7 +66,7 @@ void displayDelegateRegistration(const Transaction *transaction) {
             transaction->asset.delegateRegistration.length);
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/docs/unsupported/delegate_registration/deserializer.c
+++ b/docs/unsupported/delegate_registration/deserializer.c
@@ -86,7 +86,7 @@
 // // - transaction->nonce = U8LE(&buffer[9]);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - bytecpy(transaction->senderPublicKey, &buffer[17], 33);
+// // - MEMCOPY(transaction->senderPublicKey, &buffer[17], 33);
 // //
 // // Fee - 8 bytes
 // // - transaction->fee = U8LE(buffer, 50);
@@ -104,7 +104,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = U2LE(buffer, TYPE_OFFSET);    // 2 Bytes
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -140,7 +140,7 @@
 // // - data->timestamp = unpack4LE(buffer, 4);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - std::copy_n(&buffer.at(8), 33, data->senderPublicKey.begin());
+// // - MEMCOPY(&buffer.at(8), data->senderPublicKey, 33);
 // //
 // // Fee - 8 bytes
 // // - data->fee = unpack8LE(buffer, 41);
@@ -159,7 +159,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = buffer[TYPE_OFFSET_V1];       // 1 Byte
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET_V1],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -301,7 +301,7 @@
 //             : internalDeserializeLegacy(&transaction, buffer, size);
 
 //     if (!successful) {
-//         explicit_bzero(&transaction, sizeof(transaction));
+//         MEMSET_TYPE_BZERO(&transaction, Transaction);
 //     }
 
 //     return successful;

--- a/docs/unsupported/delegate_registration/display_ux.c
+++ b/docs/unsupported/delegate_registration/display_ux.c
@@ -54,12 +54,14 @@
 // #include "display/context.h"
 // #include "display/display.h"
 
+// #include "utils/utils.h"
+
 // ////////////////////////////////////////////////////////////////////////////////
 // extern void SetUxDisplay(size_t steps, bool isExtended);
 
 // ////////////////////////////////////////////////////////////////////////////////
 // void SetUx(const Transaction *transaction) {
-//     explicit_bzero(&displayCtx, sizeof(displayCtx));
+//     MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
 //     const bool hasVendorField = transaction->vendorFieldLength > 0;
 

--- a/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
+++ b/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
@@ -57,9 +57,9 @@ void displayDelegateResignation(const Transaction *transaction) {
     const char *const LABEL_PUBLICKEY       = "PublicKey";
     const size_t LABEL_PUBLICKEY_SIZE       = 10;
 
-    bytecpy((char *)displayCtx.operation, LABEL, LABEL_SIZE);
-    bytecpy((char *)displayCtx.title[0], LABEL_PUBLICKEY, LABEL_PUBLICKEY_SIZE);
-    bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
+    MEMCOPY(displayCtx.operation, LABEL, LABEL_SIZE);
+    MEMCOPY(displayCtx.title[0], LABEL_PUBLICKEY, LABEL_PUBLICKEY_SIZE);
+    MEMCOPY(displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Delegate PublicKey
     BytesToHex(transaction->senderPublicKey, PUBLICKEY_COMPRESSED_LEN,

--- a/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
+++ b/docs/unsupported/delegate_resignation/delegate_resignation_ux.c
@@ -43,7 +43,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -66,7 +66,7 @@ void displayDelegateResignation(const Transaction *transaction) {
                displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/docs/unsupported/delegate_resignation/deserializer.c
+++ b/docs/unsupported/delegate_resignation/deserializer.c
@@ -86,7 +86,7 @@
 // // - transaction->nonce = U8LE(&buffer[9]);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - bytecpy(transaction->senderPublicKey, &buffer[17], 33);
+// // - MEMCOPY(transaction->senderPublicKey, &buffer[17], 33);
 // //
 // // Fee - 8 bytes
 // // - transaction->fee = U8LE(buffer, 50);
@@ -104,7 +104,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = U2LE(buffer, TYPE_OFFSET);    // 2 Bytes
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -140,7 +140,7 @@
 // // - data->timestamp = unpack4LE(buffer, 4);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - std::copy_n(&buffer.at(8), 33, data->senderPublicKey.begin());
+// // - MEMCOPY(&buffer.at(8), data->senderPublicKey, 33);
 // //
 // // Fee - 8 bytes
 // // - data->fee = unpack8LE(buffer, 41);
@@ -159,7 +159,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = buffer[TYPE_OFFSET_V1];       // 1 Byte
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET_V1],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -301,7 +301,7 @@
 //             : internalDeserializeLegacy(&transaction, buffer, size);
 
 //     if (!successful) {
-//         explicit_bzero(&transaction, sizeof(transaction));
+//         MEMSET_TYPE_BZERO(&transaction, Transaction);
 //     }
 
 //     return successful;

--- a/docs/unsupported/delegate_resignation/display_ux.c
+++ b/docs/unsupported/delegate_resignation/display_ux.c
@@ -54,12 +54,14 @@
 // #include "display/context.h"
 // #include "display/display.h"
 
+// #include "utils/utils.h"
+
 // ////////////////////////////////////////////////////////////////////////////////
 // extern void SetUxDisplay(size_t steps, bool isExtended);
 
 // ////////////////////////////////////////////////////////////////////////////////
 // void SetUx(const Transaction *transaction) {
-//     explicit_bzero(&displayCtx, sizeof(displayCtx));
+//     MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
 //     const bool hasVendorField = transaction->vendorFieldLength > 0;
 

--- a/docs/unsupported/multi_payment/deserializer.c
+++ b/docs/unsupported/multi_payment/deserializer.c
@@ -86,7 +86,7 @@
 // // - transaction->nonce = U8LE(&buffer[9]);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - bytecpy(transaction->senderPublicKey, &buffer[17], 33);
+// // - MEMCOPY(transaction->senderPublicKey, &buffer[17], 33);
 // //
 // // Fee - 8 bytes
 // // - transaction->fee = U8LE(buffer, 50);
@@ -104,7 +104,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = U2LE(buffer, TYPE_OFFSET);    // 2 Bytes
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -140,7 +140,7 @@
 // // - data->timestamp = unpack4LE(buffer, 4);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - std::copy_n(&buffer.at(8), 33, data->senderPublicKey.begin());
+// // - MEMCOPY(&buffer.at(8), data->senderPublicKey, 33);
 // //
 // // Fee - 8 bytes
 // // - data->fee = unpack8LE(buffer, 41);
@@ -159,7 +159,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = buffer[TYPE_OFFSET_V1];       // 1 Byte
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET_V1],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -301,7 +301,7 @@
 //             : internalDeserializeLegacy(&transaction, buffer, size);
 
 //     if (!successful) {
-//         explicit_bzero(&transaction, sizeof(transaction));
+//         MEMSET_TYPE_BZERO(&transaction, Transaction);
 //     }
 
 //     return successful;

--- a/docs/unsupported/multi_payment/display_ux.c
+++ b/docs/unsupported/multi_payment/display_ux.c
@@ -55,12 +55,14 @@
 // #include "display/context.h"
 // #include "display/display.h"
 
+// #include "utils/utils.h"
+
 // ////////////////////////////////////////////////////////////////////////////////
 // extern void SetUxDisplay(size_t steps, bool isExtended);
 
 // ////////////////////////////////////////////////////////////////////////////////
 // void SetUx(const Transaction *transaction) {
-//     explicit_bzero(&displayCtx, sizeof(displayCtx));
+//     MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
 //     const bool hasVendorField = transaction->vendorFieldLength > 0;
 

--- a/docs/unsupported/multi_payment/multi_payment.c
+++ b/docs/unsupported/multi_payment/multi_payment.c
@@ -63,7 +63,7 @@
 // - payments->amounts[i] = U8LE(&buffer[sizeof(uint16_t) + (i * sizeof(uint64_t))], sizeof(uint64_t))
 //
 // Addresses[] - 21 Bytes * n_payments
-// - bytecpy(&payments->addresses[i * 21], &buffer[(sizeof(uint16_t) + (i * (sizeof(uint64_t) + 21))], 21);
+// - MEMCOPY(&payments->addresses[i * 21], &buffer[(sizeof(uint16_t) + (i * (sizeof(uint64_t) + 21))], 21);
 //
 // ---
 bool deserializeMultiPayment(MultiPaymentAsset *payments,
@@ -75,7 +75,7 @@ bool deserializeMultiPayment(MultiPaymentAsset *payments,
         payments->amounts[i] = U8LE(&buffer[sizeof(uint16_t) + i * sizeof(uint64_t)],
                                     sizeof(uint64_t));
 
-        bytecpy(&payments->addresses[i * ADDRESS_HASH_LEN],
+        MEMCOPY(&payments->addresses[i * ADDRESS_HASH_LEN],
                 &buffer[sizeof(uint16_t) + payments->n_payments * sizeof(uint64_t) + i * ADDRESS_HASH_LEN],
                 ADDRESS_HASH_LEN);
     }

--- a/docs/unsupported/multi_payment/multi_payment_ux.c
+++ b/docs/unsupported/multi_payment/multi_payment_ux.c
@@ -42,7 +42,7 @@
 
 #include "operations/transactions/transaction.h"
 
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"

--- a/docs/unsupported/multi_payment/multi_payment_ux.c
+++ b/docs/unsupported/multi_payment/multi_payment_ux.c
@@ -61,14 +61,10 @@ void displayMultiPayment(const Transaction *transaction) {
     const char *const LABEL_TOTAL_AMOUNT    = "Total Amount";
     const size_t LABEL_TOTAL_AMOUNT_SIZE    = 13;
 
-    bytecpy((char *)displayCtx.operation, LABEL,
-                                          LABEL_SIZE);
-    bytecpy((char *)displayCtx.title[0], LABEL_COUNT,
-                                         LABEL_COUNT_SIZE);
-    bytecpy((char *)displayCtx.title[1], LABEL_TOTAL_AMOUNT,
-                                         LABEL_TOTAL_AMOUNT_SIZE);
-    bytecpy((char *)displayCtx.title[2], LABEL_FEE,
-                                         LABEL_FEE_SIZE);
+    MEMCOPY(displayCtx.operation, LABEL, LABEL_SIZE);
+    MEMCOPY(displayCtx.title[0], LABEL_COUNT, LABEL_COUNT_SIZE);
+    MEMCOPY(displayCtx.title[1], LABEL_TOTAL_AMOUNT, LABEL_TOTAL_AMOUNT_SIZE);
+    MEMCOPY(displayCtx.title[2], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Payment Count
 

--- a/docs/unsupported/multi_signature/deserializer.c
+++ b/docs/unsupported/multi_signature/deserializer.c
@@ -86,7 +86,7 @@
 // // - transaction->nonce = U8LE(&buffer[9]);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - bytecpy(transaction->senderPublicKey, &buffer[17], 33);
+// // - MEMCOPY(transaction->senderPublicKey, &buffer[17], 33);
 // //
 // // Fee - 8 bytes
 // // - transaction->fee = U8LE(buffer, 50);
@@ -104,7 +104,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = U2LE(buffer, TYPE_OFFSET);    // 2 Bytes
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -140,7 +140,7 @@
 // // - data->timestamp = unpack4LE(buffer, 4);
 // //
 // // SenderPublicKey - 33 Bytes:
-// // - std::copy_n(&buffer.at(8), 33, data->senderPublicKey.begin());
+// // - MEMCOPY(&buffer.at(8), data->senderPublicKey, 33);
 // //
 // // Fee - 8 bytes
 // // - data->fee = unpack8LE(buffer, 41);
@@ -159,7 +159,7 @@
 //     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
 //     transaction->type               = buffer[TYPE_OFFSET_V1];       // 1 Byte
 
-//     bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+//     MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
 //             &buffer[SENDER_PUBLICKEY_OFFSET_V1],
 //             PUBLICKEY_COMPRESSED_LEN);
 
@@ -301,7 +301,7 @@
 //             : internalDeserializeLegacy(&transaction, buffer, size);
 
 //     if (!successful) {
-//         explicit_bzero(&transaction, sizeof(transaction));
+//         MEMSET_TYPE_BZERO(&transaction, Transaction);
 //     }
 
 //     return successful;

--- a/docs/unsupported/multi_signature/display_ux.c
+++ b/docs/unsupported/multi_signature/display_ux.c
@@ -55,12 +55,14 @@
 // #include "display/context.h"
 // #include "display/display.h"
 
+// #include "utils/utils.h"
+
 // ////////////////////////////////////////////////////////////////////////////////
 // extern void SetUxDisplay(size_t steps, bool isExtended);
 
 // ////////////////////////////////////////////////////////////////////////////////
 // void SetUx(const Transaction *transaction) {
-//     explicit_bzero(&displayCtx, sizeof(displayCtx));
+//     MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
 //     const bool hasVendorField = transaction->vendorFieldLength > 0;
 

--- a/docs/unsupported/multi_signature/multi_signature.c
+++ b/docs/unsupported/multi_signature/multi_signature.c
@@ -63,7 +63,7 @@
 // - multiSig->count = buffer[1];
 //
 // PublicKeys - 33N Bytes
-// - bytecpy(&multiSig->keys[0], &buffer[2], multiSig->count);
+// - MEMCOPY(&multiSig->keys[0], &buffer[2], multiSig->count);
 //
 // ---
 bool deserializeMultiSignature(MultiSignature *multiSignature,
@@ -75,7 +75,7 @@ bool deserializeMultiSignature(MultiSignature *multiSignature,
 
     multiSig->min = buffer[0];
     multiSig->count = buffer[1];
-    bytecpy(&multiSig->keys[0], &buffer[2], multiSig->count);
+    MEMCOPY(&multiSig->keys[0], &buffer[2], multiSig->count);
 
     return true;
 }

--- a/docs/unsupported/multi_signature/multi_signature_ux.c
+++ b/docs/unsupported/multi_signature/multi_signature_ux.c
@@ -58,9 +58,9 @@ void displayMultiSignature(const Transaction *transaction) {
     const char *const LABEL_COUNT       = "Key Count";
     const size_t LABEL_COUNT_SIZE       = 10;
 
-    bytecpy((char *)displayCtx.operation, LABEL, LABEL_SIZE);
-    bytecpy((char *)displayCtx.title[0], LABEL_COUNT, LABEL_COUNT_SIZE);
-    bytecpy((char *)displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
+    MEMCOPY(displayCtx.operation, LABEL, LABEL_SIZE);
+    MEMCOPY(displayCtx.title[0], LABEL_COUNT, LABEL_COUNT_SIZE);
+    MEMCOPY(displayCtx.title[1], LABEL_FEE, LABEL_FEE_SIZE);
 
     // Key Count
     UintToString(transaction->asset.multiSignature.count,

--- a/docs/unsupported/multi_signature/multi_signature_ux.c
+++ b/docs/unsupported/multi_signature/multi_signature_ux.c
@@ -67,7 +67,7 @@ void displayMultiSignature(const Transaction *transaction) {
                  displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/src/approval.c
+++ b/src/approval.c
@@ -55,6 +55,8 @@
 
 #include "display/context.h"
 
+#include "utils/utils.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 extern void ui_idle(void);
 
@@ -66,7 +68,7 @@ union {
 
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int ioApprove(const bagl_element_t *e) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
     unsigned short tx = 0;
 
@@ -84,7 +86,7 @@ unsigned int ioApprove(const bagl_element_t *e) {
                              HASH_32_LEN,
                              &privateKey);
 
-    explicit_bzero(privateKeyData, sizeof(privateKeyData));
+    MEMSET_BZERO(privateKeyData, sizeof(privateKeyData));
 
     if (tmpCtx.signing.curve == CX_CURVE_256K1) {
         uint8_t hash[CX_SHA256_SIZE];
@@ -97,8 +99,8 @@ unsigned int ioApprove(const bagl_element_t *e) {
             : signEcdsa(&privateKey, hash, G_io_apdu_buffer, SIG_ECDSA_MAX_LEN);
     }
 
-    explicit_bzero(&privateKey, sizeof(privateKey));
-    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
+    MEMSET_TYPE_BZERO(&privateKey, cx_ecfp_private_key_t);
+    MEMSET_BZERO(&tmpCtx, sizeof(tmpCtx));
 
     G_io_apdu_buffer[tx++] = 0x90;
     G_io_apdu_buffer[tx++] = 0x00;
@@ -115,8 +117,8 @@ unsigned int ioApprove(const bagl_element_t *e) {
 
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int ioCancel(const bagl_element_t *e) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
-    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
+    MEMSET_BZERO(&tmpCtx, sizeof(tmpCtx));
 
     G_io_apdu_buffer[0] = 0x69;
     G_io_apdu_buffer[1] = 0x85;
@@ -133,8 +135,8 @@ unsigned int ioCancel(const bagl_element_t *e) {
 
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int ioExit(const bagl_element_t *e) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
-    explicit_bzero(&tmpCtx, sizeof(tmpCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
+    MEMSET_BZERO(&tmpCtx, sizeof(tmpCtx));
 
     // Go back to the dashboard
     os_sched_exit(0);

--- a/src/constants.h
+++ b/src/constants.h
@@ -80,9 +80,9 @@ static const size_t UINT64_MAX_STRING_SIZE = 20U;
 ////////////////////////////////////////////////////////////////////////////////
 // Token
 static const size_t TOKEN_AMOUNT_MAX_CHARS  = 25U;
-static const size_t TOKEN_DECIMALS          = 8;
-static const char *const TOKEN_NAME         = "ARK ";
-static const size_t TOKEN_NAME_SIZE         = 4;        // sizeof("ARK ") - 1
+static const size_t TOKEN_DECIMALS          = 8U;
+static const char *const TOKEN_NAME         = "ARK";
+static const size_t TOKEN_NAME_LEN          = 3U;       // strlen("ARK")
 static const uint8_t TOKEN_NETWORK_BYTE     = 0x1e;     // ARK Mainnet
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/crypto/hashing.c
+++ b/src/crypto/hashing.c
@@ -33,14 +33,6 @@
 #include <cx.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-// Generate a Ripemd160 hash
-void hash160(uint8_t *in, size_t inSize, uint8_t *out) {
-    cx_ripemd160_t ripeHash;
-    cx_ripemd160_init(&ripeHash);
-    cx_hash(&ripeHash.header, CX_LAST, in, inSize, out, CX_SHA256_SIZE);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 void hash256(uint8_t *in, size_t inSize, uint8_t *out) {
     cx_sha256_t ctx;
     cx_sha256_init(&ctx);

--- a/src/crypto/hashing.h
+++ b/src/crypto/hashing.h
@@ -30,8 +30,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-////////////////////////////////////////////////////////////////////////////////
-void hash160(uint8_t *in, size_t inSize, uint8_t *out);
 void hash256(uint8_t *in, size_t inSize, uint8_t *out);
 
 #endif  // #define ARK_CRYPTO_HASHING_H

--- a/src/crypto/keys.c
+++ b/src/crypto/keys.c
@@ -58,7 +58,7 @@ size_t compressPublicKey(const uint8_t *uncompressed, uint8_t *compressed) {
             ? EC_PUBLICKEY_ODD_PREFIX
             : EC_PUBLICKEY_EVEN_PREFIX);
 
-    bytecpy(&compressed[1], &uncompressed[1], HASH_32_LEN);
+    MEMCOPY(&compressed[1], &uncompressed[1], HASH_32_LEN);
 
     return PUBLICKEY_COMPRESSED_LEN;
 }

--- a/src/crypto/schnorr_bcrypto_410.c
+++ b/src/crypto/schnorr_bcrypto_410.c
@@ -35,6 +35,8 @@
 
 #include "constants.h"
 
+#include "utils/utils.h"
+
 static unsigned char const SECP256K1_G[] = {
     // Gx: 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
     0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac,
@@ -203,7 +205,7 @@ uint32_t schnorr_sign_bcrypto_410(const uint8_t *privateKey,
 
     // R must not be '0'
     if (cx_math_is_zero(signature, d_len)) {
-        explicit_bzero(&signature, SIG_SCHNORR_LEN);
+        MEMSET_BZERO(&signature, SIG_SCHNORR_LEN);
         sig_len = 0;
         goto CLEAR_LOCALS;
     }
@@ -244,18 +246,18 @@ uint32_t schnorr_sign_bcrypto_410(const uint8_t *privateKey,
     cx_math_addm(signature + d_len, k, e, SECP256K1_N, d_len);
 
     if (cx_math_is_zero(signature + d_len, d_len)) {
-        explicit_bzero(signature, SIG_SCHNORR_LEN);
+        MEMSET_BZERO(signature, SIG_SCHNORR_LEN);
         sig_len = 0;
     }
 
     ////////////////////////////////////////////////////////////
     CLEAR_LOCALS:
-    explicit_bzero((void *)&H, sizeof(H));
-    explicit_bzero(&a, sizeof(a));
-    explicit_bzero(&k, sizeof(k));
-    explicit_bzero(&R, sizeof(R));
-    explicit_bzero(&A, sizeof(A));
-    explicit_bzero(&e, sizeof(e));
+    MEMSET_BZERO((void *)&H, sizeof(H));
+    MEMSET_BZERO(&a, sizeof(a));
+    MEMSET_BZERO(&k, sizeof(k));
+    MEMSET_BZERO(&R, sizeof(R));
+    MEMSET_BZERO(&A, sizeof(A));
+    MEMSET_BZERO(&e, sizeof(e));
 
     return sig_len;
 }

--- a/src/display/nano.c
+++ b/src/display/nano.c
@@ -61,6 +61,8 @@
 
 #include "display/context.h"
 
+#include "utils/utils.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 ux_state_t G_ux;
 
@@ -180,7 +182,7 @@ ux_flow_step_t* ux_flow_container[UX_FLOW_CONTAINTER_MAX];
 ////////////////////////////////////////////////////////////////////////////////
 // Initialize the Flow Container
 void ux_flow_container_init(size_t steps, bool isExtended) {
-    explicit_bzero(ux_flow_container, sizeof(ux_flow_container));
+    MEMSET_BZERO(ux_flow_container, sizeof(ux_flow_container));
 
     // copy all UX Flow steps to the Flow Container
     os_memmove(ux_flow_container, ux_flow_container_, sizeof(ux_flow_container_));

--- a/src/operations/message_op.h
+++ b/src/operations/message_op.h
@@ -33,7 +33,7 @@
 
 #include "constants.h"
 
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"

--- a/src/operations/message_op.h
+++ b/src/operations/message_op.h
@@ -54,7 +54,7 @@ extern void SetUxDisplay(size_t steps, bool isExtended);
 //
 // ---
 bool handleMessage(const uint8_t *buffer, size_t length) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
     if (length == 0 || length > MAX_TEXT_LEN) {
         return false;

--- a/src/operations/transactions/deserializer.c
+++ b/src/operations/transactions/deserializer.c
@@ -77,7 +77,7 @@ Transaction transaction;
 // - transaction->nonce = U8LE(&buffer[9]);
 //
 // SenderPublicKey - 33 Bytes:
-// - bytecpy(transaction->senderPublicKey, &buffer[17], 33);
+// - MEMCOPY(transaction->senderPublicKey, &buffer[17], 33);
 //
 // Fee - 8 bytes
 // - transaction->fee = U8LE(buffer, 50);
@@ -95,7 +95,7 @@ static void deserializeCommon(Transaction *transaction, const uint8_t *buffer) {
     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
     transaction->type               = U2LE(buffer, TYPE_OFFSET);    // 2 Bytes
 
-    bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+    MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
             &buffer[SENDER_PUBLICKEY_OFFSET],
             PUBLICKEY_COMPRESSED_LEN);
 
@@ -131,7 +131,7 @@ static void deserializeCommon(Transaction *transaction, const uint8_t *buffer) {
 // - data->timestamp = unpack4LE(buffer, 4);
 //
 // SenderPublicKey - 33 Bytes:
-// - std::copy_n(&buffer.at(8), 33, data->senderPublicKey.begin());
+// - MEMCOPY(&buffer.at(8), data->senderPublicKey, 33);
 //
 // Fee - 8 bytes
 // - data->fee = unpack8LE(buffer, 41);
@@ -150,7 +150,7 @@ static void deserializeCommonV1(Transaction *transaction,
     transaction->network            = buffer[NETWORK_OFFSET];       // 1 Byte
     transaction->type               = buffer[TYPE_OFFSET_V1];       // 1 Byte
 
-    bytecpy(transaction->senderPublicKey,                           // 33 Bytes
+    MEMCOPY(transaction->senderPublicKey,                           // 33 Bytes
             &buffer[SENDER_PUBLICKEY_OFFSET_V1],
             PUBLICKEY_COMPRESSED_LEN);
 
@@ -299,7 +299,7 @@ bool deserialize(const uint8_t *buffer, size_t size) {
             : internalDeserializeLegacy(&transaction, buffer, size);
 
     if (!successful) {
-        explicit_bzero(&transaction, sizeof(transaction));
+        MEMSET_TYPE_BZERO(&transaction, Transaction);
     }
 
     return successful;

--- a/src/operations/transactions/legacy/deserialize_legacy.c
+++ b/src/operations/transactions/legacy/deserialize_legacy.c
@@ -45,7 +45,7 @@ void deserializeCommonLegacy(Transaction *transaction,
     transaction->version        = TRANSACTION_VERSION_LEGACY;
     transaction->type           = buffer[TYPE_OFFSET_LEGACY];
 
-    bytecpy(transaction->recipientId,
+    MEMCOPY(transaction->recipientId,
             &buffer[RECIPIENT_OFFSET_LEGACY],
             ADDRESS_HASH_LEN);
 

--- a/src/operations/transactions/legacy/display_legacy.c
+++ b/src/operations/transactions/legacy/display_legacy.c
@@ -42,7 +42,7 @@
 #include "transactions/ux/vendorfield_ux.h"
 
 #include "utils/base58.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -70,12 +70,12 @@ void setTransferLegacy(const Transaction *transaction) {
     displayCtx.text[0][ADDRESS_LEN]  = ' ';
 
     // Amount
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->amount,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[2], sizeof(displayCtx.text[2]));
 
@@ -94,7 +94,7 @@ static void setVoteLegacy(const Transaction *transaction) {
     const size_t voteOffset = 67;
     bytecpy((char*)displayCtx.text[0], transaction->assetPtr, voteOffset);
 
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/src/operations/transactions/legacy/display_legacy.c
+++ b/src/operations/transactions/legacy/display_legacy.c
@@ -60,12 +60,9 @@ void setTransferLegacy(const Transaction *transaction) {
     SPRINTF(displayCtx.title[2], "Fee:");
 
     // RecipientId
-    encodeBase58PublicKey((uint8_t*)transaction->recipientId,
-                          ADDRESS_HASH_LEN,
-                          (uint8_t*)displayCtx.text[0],
-                          sizeof(displayCtx.text[0]),
-                          transaction->recipientId[0],
-                          1U);
+    Base58CheckEncode(transaction->recipientId, ADDRESS_HASH_LEN,
+                      displayCtx.text[0], sizeof(displayCtx.text[0]));
+
     // somehow prevents displaying bad chars?
     // legacy, so let's not spend too much time on it.
     displayCtx.text[0][ADDRESS_LEN]  = ' ';

--- a/src/operations/transactions/legacy/display_legacy.c
+++ b/src/operations/transactions/legacy/display_legacy.c
@@ -42,6 +42,7 @@
 #include "transactions/ux/vendorfield_ux.h"
 
 #include "utils/base58.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/legacy/display_legacy.c
+++ b/src/operations/transactions/legacy/display_legacy.c
@@ -92,7 +92,7 @@ static void setVoteLegacy(const Transaction *transaction) {
     SPRINTF(displayCtx.title[1], "Fee:");
 
     const size_t voteOffset = 67;
-    bytecpy((char*)displayCtx.text[0], transaction->assetPtr, voteOffset);
+    MEMCOPY(displayCtx.text[0], transaction->assetPtr, voteOffset);
 
     TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
@@ -101,7 +101,7 @@ static void setVoteLegacy(const Transaction *transaction) {
 
 ////////////////////////////////////////////////////////////////////////////////
 void SetUxLegacy(const Transaction *transaction) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
     switch (transaction->type) {
         case TRANSFER_TYPE:

--- a/src/operations/transactions/types/htlc_claim.c
+++ b/src/operations/transactions/types/htlc_claim.c
@@ -47,10 +47,10 @@
 // Internals:
 //
 // Lock Transaction Id - 32 Bytes:
-// - bytecpy(claim->id, &buffer[0], 32);
+// - MEMCOPY(claim->id, &buffer[0], 32);
 //
 // Unlock Secret - 32 Bytes
-// - bytecpy(claim->secret, &buffer[32], 32);
+// - MEMCOPY(claim->secret, &buffer[32], 32);
 //
 // ---
 bool deserializeHtlcClaim(HtlcClaim *claim, const uint8_t *buffer, size_t size) {
@@ -58,8 +58,8 @@ bool deserializeHtlcClaim(HtlcClaim *claim, const uint8_t *buffer, size_t size) 
         return false;
     }
 
-    bytecpy(claim->id, &buffer[0], HASH_32_LEN);                    // 32 Bytes
-    bytecpy(claim->secret, &buffer[HASH_32_LEN], HASH_32_LEN);      // 32 Bytes
+    MEMCOPY(claim->id, &buffer[0], HASH_32_LEN);                    // 32 Bytes
+    MEMCOPY(claim->secret, &buffer[HASH_32_LEN], HASH_32_LEN);      // 32 Bytes
 
     return true;
 }

--- a/src/operations/transactions/types/htlc_lock.c
+++ b/src/operations/transactions/types/htlc_lock.c
@@ -86,3 +86,4 @@ bool deserializeHtlcLock(HtlcLock *lock, const uint8_t *buffer, size_t size) {
 
     return true;
 }
+

--- a/src/operations/transactions/types/htlc_lock.c
+++ b/src/operations/transactions/types/htlc_lock.c
@@ -51,7 +51,7 @@
 // - lock->amount = U4LE(buffer, 0);
 //
 // Secret Hash - 32 Bytes
-// - bytecpy(lock->secretHash, &buffer[8], 32);
+// - MEMCOPY(lock->secretHash, &buffer[8], 32);
 //
 // Expiration Type- 1 Byte
 // - lock->expirationType = buffer[40];
@@ -60,7 +60,7 @@
 // - lock->expirationValue = U4LE(buffer, 41);
 //
 // RecipientId - 21 Bytes
-// - bytecpy(lock->recipientId, &buffer[45], 21);
+// - MEMCOPY(lock->recipientId, &buffer[45], 21);
 //
 // ---
 bool deserializeHtlcLock(HtlcLock *lock, const uint8_t *buffer, size_t size) {
@@ -70,27 +70,19 @@ bool deserializeHtlcLock(HtlcLock *lock, const uint8_t *buffer, size_t size) {
 
     size_t offset = 0;
 
-    lock->amount            = U8LE(buffer, offset);             // 8 Bytes
+    lock->amount = U8LE(buffer, offset);                            // 8 Bytes
+    offset += sizeof(uint64_t);
 
-    offset += sizeof(uint64_t);     // += sizeof(amount)
+    MEMCOPY(lock->secretHash, &buffer[offset], HASH_32_LEN);        // 32 Bytes
+    offset += HASH_32_LEN;
 
-    bytecpy(lock->secretHash,                                   // 32 Bytes
-            &buffer[offset],
-            HASH_32_LEN);
+    lock->expirationType = buffer[offset];                          // 1 Byte
+    offset += sizeof(uint8_t);
 
-    offset += HASH_32_LEN;          // += sizeof(secretHash)
+    lock->expiration = U4LE(buffer, offset);                        // 4 Bytes
+    offset += sizeof(uint32_t);
 
-    lock->expirationType    = buffer[offset];                   // 1 Byte
-
-    offset += sizeof(uint8_t);      // += sizeof(expirationType)
-
-    lock->expiration        = U4LE(buffer, offset);             // 4 Bytes
-
-    offset += sizeof(uint32_t);     // += sizeof(expiration)
-
-    bytecpy(lock->recipientId,                                  // 21 Bytes
-            &buffer[offset],
-            ADDRESS_HASH_LEN);
+    MEMCOPY(lock->recipientId, &buffer[offset], ADDRESS_HASH_LEN);  // 21 Bytes
 
     return true;
 }

--- a/src/operations/transactions/types/htlc_refund.c
+++ b/src/operations/transactions/types/htlc_refund.c
@@ -47,7 +47,7 @@
 // Internals:
 //
 // Lock Transaction Id - 32 Bytes:
-// - bytecpy(refund->id, &buffer[0], 32);
+// - MEMCOPY(refund->id, &buffer[0], 32);
 //
 // ---
 bool deserializeHtlcRefund(HtlcRefund *refund,
@@ -57,7 +57,7 @@ bool deserializeHtlcRefund(HtlcRefund *refund,
         return false;
     }
 
-    bytecpy(refund->id, &buffer[0], HASH_32_LEN);               // 32 Bytes
+    MEMCOPY(refund->id, &buffer[0], HASH_32_LEN);               // 32 Bytes
 
     return true;
 }

--- a/src/operations/transactions/types/ipfs.c
+++ b/src/operations/transactions/types/ipfs.c
@@ -50,7 +50,7 @@
 // - ipfs->length = buffer[1] + 2U;
 //
 // Dag - 0 <=> 64 Bytes
-// - bytecpy(ipfs->dag, buffer, ipfs->length);
+// - MEMCOPY(ipfs->dag, buffer, ipfs->length);
 //
 // ---
 bool deserializeIpfs(Ipfs *ipfs, const uint8_t *buffer, size_t size) {
@@ -67,7 +67,7 @@ bool deserializeIpfs(Ipfs *ipfs, const uint8_t *buffer, size_t size) {
         return false;
     }
 
-    bytecpy(ipfs->dag, buffer, size);                       // 0 <=> 64 Bytes
+    MEMCOPY(ipfs->dag, buffer, size);                       // 0 <=> 64 Bytes
 
     return true;
 }

--- a/src/operations/transactions/types/second_signature.c
+++ b/src/operations/transactions/types/second_signature.c
@@ -47,7 +47,7 @@
 // Internals:
 //
 // Second PublicKey - 33 Bytes:
-// - bytecpy(registration->publicKey, buffer, 33);
+// - MEMCOPY(registration->publicKey, buffer, 33);
 //
 // ---
 bool deserializeSecondSignature(SecondSignatureRegistration *registration,
@@ -57,7 +57,7 @@ bool deserializeSecondSignature(SecondSignatureRegistration *registration,
         return false;
     }
 
-    bytecpy(registration->publicKey, buffer, PUBLICKEY_COMPRESSED_LEN);
+    MEMCOPY(registration->publicKey, buffer, PUBLICKEY_COMPRESSED_LEN);
 
     return true;
 }

--- a/src/operations/transactions/types/transfer.c
+++ b/src/operations/transactions/types/transfer.c
@@ -54,7 +54,7 @@
 // - transfer->expiration = U4LE(buffer, 8);
 //
 // RecipientId - 21 Bytes:
-// - bytecpy(transfer->recipientId, &buffer[12], 21);
+// - MEMCOPY(transfer->recipientId, &buffer[12], 21);
 //
 // ---
 bool deserializeTransfer(Transfer *transfer,
@@ -68,7 +68,7 @@ bool deserializeTransfer(Transfer *transfer,
 
     transfer->amount        = U8LE(buffer, 0);                      // 8 Bytes
     transfer->expiration    = U4LE(buffer, sizeof(uint64_t));       // 4 Bytes
-    bytecpy(transfer->recipientId,                                  // 21 Bytes
+    MEMCOPY(transfer->recipientId,                                  // 21 Bytes
             &buffer[sizeof(uint64_t) + sizeof(uint32_t)],
             ADDRESS_HASH_LEN);
 

--- a/src/operations/transactions/types/vote.c
+++ b/src/operations/transactions/types/vote.c
@@ -50,7 +50,7 @@
 // - vote->n_votes = buffer[0];
 //
 // Vote - 1 + 33(Compressed PublicKey) Bytes:
-// - bytecpy(vote->data, &buffer[1], 34);
+// - MEMCOPY(vote->data, &buffer[1], 34);
 //
 // ---
 bool deserializeVote(Vote *vote, const uint8_t *buffer, size_t size) {
@@ -59,7 +59,7 @@ bool deserializeVote(Vote *vote, const uint8_t *buffer, size_t size) {
     }
 
     // skip vote count
-    bytecpy(vote->data, &buffer[sizeof(uint8_t)], VOTE_LEN);        // 34 Bytes
+    MEMCOPY(vote->data, &buffer[sizeof(uint8_t)], VOTE_LEN);        // 34 Bytes
 
     return true;
 }

--- a/src/operations/transactions/ux/display_ux.c
+++ b/src/operations/transactions/ux/display_ux.c
@@ -45,12 +45,14 @@
 #include "display/context.h"
 #include "display/display.h"
 
+#include "utils/utils.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 extern void SetUxDisplay(size_t steps, bool isExtended);
 
 ////////////////////////////////////////////////////////////////////////////////
 void SetUx(const Transaction *transaction) {
-    explicit_bzero(&displayCtx, sizeof(displayCtx));
+    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
 
     const bool hasVendorField = transaction->vendorFieldLength > 0;
 

--- a/src/operations/transactions/ux/htlc_claim_ux.c
+++ b/src/operations/transactions/ux/htlc_claim_ux.c
@@ -46,7 +46,7 @@ void SetUxHtlcClaim(const Transaction *transaction) {
                displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Secret
-    bytecpy(displayCtx.text[1],
+    MEMCOPY(displayCtx.text[1],
             transaction->asset.htlcClaim.secret,
             HASH_32_LEN);
 }

--- a/src/operations/transactions/ux/htlc_claim_ux.c
+++ b/src/operations/transactions/ux/htlc_claim_ux.c
@@ -31,6 +31,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
+#include "utils/print.h"
 #include "utils/utils.h"
 
 #include "display/context.h"

--- a/src/operations/transactions/ux/htlc_lock_ux.c
+++ b/src/operations/transactions/ux/htlc_lock_ux.c
@@ -52,12 +52,8 @@ void SetUxHtlcLock(const Transaction *transaction) {
     SPRINTF(displayCtx.title[4], "%s:", UX_LABEL_FEE);
 
     // RecipientId
-    encodeBase58PublicKey((uint8_t *)transaction->asset.htlcLock.recipientId,
-                          ADDRESS_HASH_LEN,
-                          (uint8_t *)displayCtx.text[0],
-                          ADDRESS_LEN,
-                          transaction->asset.htlcLock.recipientId[0],
-                          1);
+    Base58CheckEncode(transaction->asset.htlcLock.recipientId, ADDRESS_HASH_LEN,
+                      displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Secret Hash
     BytesToHex(transaction->asset.htlcLock.secretHash, HASH_32_LEN,

--- a/src/operations/transactions/ux/htlc_lock_ux.c
+++ b/src/operations/transactions/ux/htlc_lock_ux.c
@@ -36,7 +36,7 @@
 
 #include "utils/base58.h"
 #include "utils/hex.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -72,12 +72,12 @@ void SetUxHtlcLock(const Transaction *transaction) {
                  sizeof(displayCtx.text[2]));
 
     // Amount
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->asset.htlcLock.amount,
                         displayCtx.text[3], sizeof(displayCtx.text[3]));
 
     // Fees
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[4], sizeof(displayCtx.text[4]));
 

--- a/src/operations/transactions/ux/htlc_lock_ux.c
+++ b/src/operations/transactions/ux/htlc_lock_ux.c
@@ -36,6 +36,7 @@
 
 #include "utils/base58.h"
 #include "utils/hex.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/ux/htlc_refund_ux.c
+++ b/src/operations/transactions/ux/htlc_refund_ux.c
@@ -31,6 +31,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
+#include "utils/print.h"
 #include "utils/utils.h"
 
 #include "display/context.h"

--- a/src/operations/transactions/ux/ipfs_ux.c
+++ b/src/operations/transactions/ux/ipfs_ux.c
@@ -34,7 +34,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/base58.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -46,7 +46,7 @@ void SetUxIpfs(const Transaction *transaction) {
     SPRINTF(displayCtx.title_ext, "%s:", UX_IPFS_LABELS[1]);
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[0], sizeof(displayCtx.text[0]));
 

--- a/src/operations/transactions/ux/ipfs_ux.c
+++ b/src/operations/transactions/ux/ipfs_ux.c
@@ -34,6 +34,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/base58.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/ux/ipfs_ux.c
+++ b/src/operations/transactions/ux/ipfs_ux.c
@@ -53,8 +53,6 @@ void SetUxIpfs(const Transaction *transaction) {
 
     // DAG
     size_t dagLen = MAX_TEXT_LEN;
-    btchip_encode_base58(transaction->asset.ipfs.dag,
-                         transaction->asset.ipfs.length,
-                         (uint8_t *)displayCtx.text_ext,
-                         &dagLen);
+    Base58Encode(transaction->asset.ipfs.dag, transaction->asset.ipfs.length,
+                 displayCtx.text_ext, &dagLen);
 }

--- a/src/operations/transactions/ux/second_signature_ux.c
+++ b/src/operations/transactions/ux/second_signature_ux.c
@@ -31,7 +31,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -48,7 +48,7 @@ void SetUxSecondSignature(const Transaction *transaction) {
                displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/src/operations/transactions/ux/second_signature_ux.c
+++ b/src/operations/transactions/ux/second_signature_ux.c
@@ -31,6 +31,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/ux/transfer_ux.c
+++ b/src/operations/transactions/ux/transfer_ux.c
@@ -48,12 +48,8 @@ void SetUxTransfer(const Transaction *transaction) {
     SPRINTF(displayCtx.title[3], "%s:", UX_LABEL_FEE);
 
     // RecipientId
-    encodeBase58PublicKey((uint8_t *)transaction->asset.transfer.recipientId,
-                          ADDRESS_HASH_LEN,
-                          (uint8_t *)displayCtx.text[0],
-                          sizeof(displayCtx.text[0]),
-                          transaction->asset.transfer.recipientId[0],
-                          1U);
+    Base58CheckEncode(transaction->asset.transfer.recipientId, ADDRESS_HASH_LEN,
+                      displayCtx.text[0], sizeof(displayCtx.text[0]));
 
     // Expiration
     UintToString(transaction->asset.transfer.expiration,

--- a/src/operations/transactions/ux/transfer_ux.c
+++ b/src/operations/transactions/ux/transfer_ux.c
@@ -33,6 +33,7 @@
 #include "transactions/ux/vendorfield_ux.h"
 
 #include "utils/base58.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/ux/transfer_ux.c
+++ b/src/operations/transactions/ux/transfer_ux.c
@@ -33,7 +33,7 @@
 #include "transactions/ux/vendorfield_ux.h"
 
 #include "utils/base58.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -59,12 +59,12 @@ void SetUxTransfer(const Transaction *transaction) {
                  displayCtx.text[1], sizeof(displayCtx.text[1]));
 
     // Amount
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->asset.transfer.amount,
                         displayCtx.text[2], sizeof(displayCtx.text[2]));
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[3], sizeof(displayCtx.text[3]));
 

--- a/src/operations/transactions/ux/vendorfield_ux.c
+++ b/src/operations/transactions/ux/vendorfield_ux.c
@@ -30,6 +30,7 @@
 
 #include "operations/transactions/transaction.h"
 
+#include "utils/print.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -38,7 +39,7 @@
 void setVendorField(const Transaction *transaction) {
     SPRINTF(displayCtx.title_ext, "%s:", UX_VENDORFIELD_LABEL);
 
-    snprintf(displayCtx.text_ext,
+    SNPRINTF(displayCtx.text_ext,
              transaction->vendorFieldLength + 1,
              "%s", transaction->vendorField);
 }

--- a/src/operations/transactions/ux/vote_ux.c
+++ b/src/operations/transactions/ux/vote_ux.c
@@ -33,6 +33,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
+#include "utils/print.h"
 #include "utils/str.h"
 #include "utils/utils.h"
 

--- a/src/operations/transactions/ux/vote_ux.c
+++ b/src/operations/transactions/ux/vote_ux.c
@@ -33,7 +33,7 @@
 #include "operations/transactions/transaction.h"
 
 #include "utils/hex.h"
-#include "utils/print.h"
+#include "utils/str.h"
 #include "utils/utils.h"
 
 #include "display/context.h"
@@ -53,7 +53,7 @@ void SetUxVote(const Transaction *transaction) {
                &displayCtx.text[0][1], sizeof(displayCtx.text[0]) - 1);
 
     // Fee
-    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_SIZE, TOKEN_DECIMALS,
+    TokenAmountToString(TOKEN_NAME, TOKEN_NAME_LEN, TOKEN_DECIMALS,
                         transaction->fee,
                         displayCtx.text[1], sizeof(displayCtx.text[1]));
 }

--- a/src/utils/base58.c
+++ b/src/utils/base58.c
@@ -142,13 +142,13 @@ int encodeBase58PublicKey(uint8_t *in, size_t inSize,
         hash160(in, inSize, &temp[versionSize]);
     }
     else {
-        bytecpy(&temp[versionSize], &in[versionSize], HASH_20_LEN);
+        MEMCOPY(&temp[versionSize], &in[versionSize], HASH_20_LEN);
     }
 
     hash256(temp, ripeLength, checksum);
     hash256(checksum, HASH_32_LEN, checksum);
 
-    bytecpy(&temp[ripeLength], checksum, 4);
+    MEMCOPY(&temp[ripeLength], checksum, 4);
 
     return btchip_encode_base58(temp, ripeLength + 4, out, &outSize);
 }

--- a/src/utils/base58.h
+++ b/src/utils/base58.h
@@ -49,12 +49,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-////////////////////////////////////////////////////////////////////////////////
-int btchip_encode_base58(const unsigned char *in, size_t length,
-                         unsigned char *out, size_t *outlen);
+int Base58Encode(const uint8_t *in, size_t length, char *out, size_t *outlen);
 
-int encodeBase58PublicKey(uint8_t *in, size_t inSize,
-                          uint8_t *out, size_t outSize,
-                          uint16_t version, uint8_t alreadyHashed);
+int Base58CheckEncode(const uint8_t *in, size_t length,
+                      char *out, size_t outLen);
 
 #endif  // ARK_UTILS_BASE58_H

--- a/src/utils/hex.c
+++ b/src/utils/hex.c
@@ -30,11 +30,19 @@
 #include <stdint.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-// Convert Bytes to a Hex string.
-// NULL terminated at (n + 1)
+// Convert Bytes to a Hex string, with null-terminator at N+1.
+//
+// @param const uint8_t *src:   source byte-array.
+// @param size_t srcLen:        length of the byte-array.
+// @param char *dst:            destination hex-string buffer.
+// @param size_t dstMax:        max length of writable space.
+//
+// @return size_t: final length w/null-terminator if successful, otherwise '0'.
+//
+// ---
 size_t BytesToHex(const uint8_t *src, size_t srcLen, char *dst, size_t dstMax) {
-    if (src == NULL || dst == NULL || (srcLen * 2) + 1 > dstMax) {
-        return 0;
+    if (src == NULL || dst == NULL || (srcLen * 2U) + 1U > dstMax) {
+        return 0U;
     }
 
     const char *const HEX_DIGITS = "0123456789abcdef";
@@ -42,12 +50,12 @@ size_t BytesToHex(const uint8_t *src, size_t srcLen, char *dst, size_t dstMax) {
     size_t len = srcLen;
 
     do {
-        *dst++ = HEX_DIGITS[(*src >> 4) & 0xF];
+        *dst++ = HEX_DIGITS[(*src >> 4U) & 0xF];
         *dst++ = HEX_DIGITS[*src & 0xF];
         ++src;
-    } while (len-- > 1);
+    } while (len-- > 1U);
 
     *dst = '\0';
 
-    return (srcLen * 2) + 1;
+    return (srcLen * 2U) + 1U;
 }

--- a/src/utils/hex.h
+++ b/src/utils/hex.h
@@ -30,7 +30,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-////////////////////////////////////////////////////////////////////////////////
 size_t BytesToHex(const uint8_t *src, size_t srcLen, char *dst, size_t dstMax);
 
 #endif  // ARK_UTILS_HEX_H

--- a/src/utils/print.h
+++ b/src/utils/print.h
@@ -24,56 +24,43 @@
  * SOFTWARE.
  ******************************************************************************/
 
-#ifndef ARK_OPERATIONS_MESSAGE_H
-#define ARK_OPERATIONS_MESSAGE_H
+#ifndef ARK_UTILS_PRINT_H
+#define ARK_UTILS_PRINT_H
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+#if defined(HAVE_BOLOS_SDK)
+    #include <os.h>
+    #include <os_io_seproxyhal.h>
 
-#include "constants.h"
+    #undef SPRINTF  // redefine BOLOS version as 'SPRINTF_'
+    #define SPRINTF_(strbuf, ...) snprintf(strbuf, sizeof(strbuf), __VA_ARGS__)
 
-#include "utils/print.h"
-#include "utils/str.h"
-#include "utils/utils.h"
+    #define SNPRINTF_ snprintf
+#else  // BOLOS NOT detected
+    #include <string.h>
 
-#include "display/context.h"
-#include "display/display.h"
-
-////////////////////////////////////////////////////////////////////////////////
-static const char *const UX_MESSAGE_LABELS[]    = { "Message", "Length" };
-static const size_t UX_MESSAGE_STEPS            = 2;
+    #define SPRINTF_ sprintf
+    #define SNPRINTF_ snprintf
+#endif  // HAS_BOLOS_SDK
 
 ////////////////////////////////////////////////////////////////////////////////
-extern void SetUxDisplay(size_t steps, bool isExtended);
-
-////////////////////////////////////////////////////////////////////////////////
-// Prepare a Message Operation for Display.
+// A platform wrapper for 'sprintf'.
 //
-// - UTF8 Encoded
-// - 255 Byte Max
+// @param char *s:              pointer to the destination buffer.
+// @param const char *format:   string print format.
+// @param ...:                  variadic arguments.
 //
 // ---
-bool handleMessage(const uint8_t *buffer, size_t length) {
-    MEMSET_TYPE_BZERO(&displayCtx, DisplayContext);
+#define SPRINTF SPRINTF_
 
-    if (length == 0 || length > MAX_TEXT_LEN) {
-        return false;
-    }
+////////////////////////////////////////////////////////////////////////////////
+// A platform wrapper for 'snprintf'.
+//
+// @param char *s:              pointer to the destination buffer.
+// @param size_t size:          maximum number of bytes to be written. 
+// @param const char *format:   string print format.
+// @param ...:                  variadic arguments.
+//
+// ---
+#define SNPRINTF SNPRINTF_
 
-    SPRINTF(displayCtx.operation, "%s", UX_MESSAGE_LABELS[0]);
-    SPRINTF(displayCtx.title[0], "%s:", UX_MESSAGE_LABELS[1]);
-    SPRINTF(displayCtx.title_ext, "%s:", UX_MESSAGE_LABELS[0]);
-
-    // Message Length
-    UintToString(length, displayCtx.text[0], sizeof(displayCtx.text[0]));
-
-    // Message Text
-    SNPRINTF(displayCtx.text_ext, length + 1, "%s", buffer);
-
-    SetUxDisplay(UX_MESSAGE_STEPS, true);
-
-    return true;
-}
-
-#endif  // #define ARK_OPERATIONS_MESSAGE_H
+#endif  // ARK_UTILS_PRINT_H

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -213,8 +213,8 @@ size_t TokenAmountToString(const char *token, size_t tokenLen, size_t decimals,
         const char *const separator = ": ";
         const size_t separatorLen = 2U;
 
-        bytecpy(dst, token, tokenLen);
-        bytecpy(dst + tokenLen, separator, separatorLen);
+        MEMCOPY(dst, token, tokenLen);
+        MEMCOPY(dst + tokenLen, separator, separatorLen);
         prefixLen += separatorLen;
     }
 

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -190,7 +190,7 @@ size_t UintToString(uint64_t value, char *dst, size_t maxLen) {
 // - TokenAmountToString("ARK ", 4, 8, 1ULL, 25);
 // - "ARK: 0.00000001"
 //
-// @param const char *token     token/ticker name.
+// @param const char *token:    token/ticker name.
 // @param size_t tokenLen:      length of token, excluding the null-terminator.
 // @param size_t decimals:      decimal precision / how many values after '.'.
 // @param uint64_t amount:      unsigned value to be converted.

--- a/src/utils/str.h
+++ b/src/utils/str.h
@@ -24,18 +24,16 @@
  * SOFTWARE.
  ******************************************************************************/
 
-#ifndef ARK_UTILS_PRINT_H
-#define ARK_UTILS_PRINT_H
+#ifndef ARK_UTILS_STR_H
+#define ARK_UTILS_STR_H
 
 #include <stddef.h>
 #include <stdint.h>
 
-////////////////////////////////////////////////////////////////////////////////
 size_t UintToString(uint64_t value, char *dst, size_t maxLen);
 
-////////////////////////////////////////////////////////////////////////////////
 size_t TokenAmountToString(const char *token, size_t tokenLen, size_t decimals,
                            uint64_t amount,
                            char *dst, size_t maxLen);
 
-#endif  // ARK_UTILS_PRINT_H
+#endif  // ARK_UTILS_STR_H

--- a/src/utils/unpack.h
+++ b/src/utils/unpack.h
@@ -22,73 +22,85 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
- * -----
- * 
- * Parts of this software are based on Ledger Nano SDK
- * 
- * (c) 2017 Ledger
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  ******************************************************************************/
 
 #ifndef ARK_UTILS_UNPACK_H
 #define ARK_UTILS_UNPACK_H
 
-#if defined(HAVE_BOLOS_SDK)
-// The Ledger SDK implements 2 and 4-byte little-endian integer unpacking.
-// We only need to implement the 8-byte equivalent.
-#include <os.h>
-
-////////////////////////////////////////////////////////////////////////////////
-#define U8LE(buf, off)                                                              \
-        (((uint64_t)(U4LE(buf, off))                    & 0xFFFFFFFF)           |   \
-         ((uint64_t)(U4LE(buf, off + sizeof(uint32_t))  & 0xFFFFFFFF) << 32U))
-#else  // if not HAVE_BOLOS_SDK
-// If not using the Ledger SDK, we need to implement the unpacking macros.
-
 #include <stddef.h>
 #include <stdint.h>
 
-////////////////////////////////////////////////////////////////////////////////
-static const uint8_t U1_MAX         = 0xFF;
-static const uint16_t U2_MAX        = 0xFFFF;
-static const uint32_t U4_MAX        = 0xFFFFFFFF;
-static const uint64_t U8_MAX        = 0xFFFFFFFFFFFFFFFF;
+#if defined(HAVE_BOLOS_SDK)
+// Undef the BOLOS macros in favor of additional type-safety implemented below.
+    #undef U2LE
+    #undef U4LE
+#endif
 
+////////////////////////////////////////////////////////////////////////////////
+// Unsigned Integer Unpacking Constants
 static const size_t U1_SIZE         = sizeof(uint8_t);
 static const size_t U2_SIZE         = sizeof(uint16_t);
 static const size_t U4_SIZE         = sizeof(uint32_t);
+static const size_t U8_SIZE         = sizeof(uint64_t);
 
-static const uint16_t U1_SHIFT      = 8U;
-static const uint32_t U2_SHIFT      = 16UL;
-static const uint64_t U4_SHIFT      = 32ULL;
+static const uint8_t U1_MAX         = 0xFFU;
+static const uint16_t U2_MAX        = 0xFFFFUL;
+static const uint32_t U4_MAX        = 0xFFFFFFFFUL;
+static const uint64_t U8_MAX        = 0xFFFFFFFFFFFFFFFFULL;
+
+static const uint16_t U1_SHIFT      = U1_SIZE * U8_SIZE;
+static const uint32_t U2_SHIFT      = U2_SIZE * U8_SIZE;
+static const uint64_t U4_SHIFT      = U4_SIZE * U8_SIZE;
 
 ////////////////////////////////////////////////////////////////////////////////
-#define U2LE(src, offset)                                                               \
-    ((((uint16_t)(((src)[(offset)])                     & U1_MAX))                  |   \
-     (((uint16_t)(((src)[((offset) + U1_SIZE)])         & U1_MAX)   << U1_SHIFT)))      \
-                                                        & U2_MAX)
+// Unpack a 2-byte packed number ot its unsigned (uint16_t/unsigned short) form.
+//
+// example:
+// - uint16_t u16 = U2LE(src, offset);
+//
+// @param uint8_t src:     packed unsigned integer 2-byte array.
+// @param size_t offset:   offset in the input/src stream.
+//
+// @return uint16_t: then unpacked 2-byte value.
+//
+// ---
+#define U2LE(src, offset)                                                   \
+    ((uint16_t)((src)[(offset)]                 & U1_MAX)               |   \
+    ((uint16_t)((src)[(offset) + U1_SIZE]       & U1_MAX)   << U1_SHIFT)    \
+                                                & U2_MAX)
 
-#define U4LE(src, offset)                                                               \
-    ((((uint32_t)((U2LE((src), (offset)))               & U2_MAX))                  |   \
-     (((uint32_t)((U2LE((src), ((offset) + U2_SIZE)))   & U2_MAX)   << U2_SHIFT)))      \
-                                                        & U4_MAX)
+////////////////////////////////////////////////////////////////////////////////
+// Unpack a 4-byte packed number to its unsigned (uint32_t/unsigned int) form.
+//
+// example:
+// - uint32_t u32 = U4LE(src, offset);
+//
+// @param: uint8_t src:     packed unsigned integer 4-byte array.
+// @param: size_t offset:   offset in the input/src stream.
+//
+// @return uint32_t: then unpacked 4-byte value.
+//
+// ---
+#define U4LE(src, offset)                                                   \
+    ((uint32_t)(U2LE((src), (offset))           & U2_MAX)               |   \
+    ((uint32_t)(U2LE((src), (offset) + U2_SIZE) & U2_MAX)   << U2_SHIFT)    \
+                                                & U4_MAX)
 
-#define U8LE(src, offset)                                                               \
-    ((((uint64_t)((U4LE((src), (offset)))               & U4_MAX))                  |   \
-     (((uint64_t)((U4LE((src), ((offset) + U4_SIZE)))   & U4_MAX)   << U4_SHIFT)))      \
-                                                        & U8_MAX)
-#endif  // HAVE_BOLOS_SDK
+////////////////////////////////////////////////////////////////////////////////
+// Unpack an 8-byte packed number to its unsigned (uint64_t/unsigned long) form.
+//
+// example:
+// - uint64_t u64 = U8LE(src, offset);
+//
+// @param: uint8_t src:     packed unsigned integer 8-byte array.
+// @param: size_t offset:   offset in the input/src stream.
+//
+// @return uint64_t: then unpacked 8-byte value.
+//
+// ---
+#define U8LE(src, offset)                                                   \
+    ((uint64_t)(U4LE((src), (offset))           & U4_MAX)               |   \
+    ((uint64_t)(U4LE((src), (offset) + U4_SIZE) & U4_MAX)   << U4_SHIFT)    \
+                                                & U8_MAX)
 
 #endif  // ARK_UTILS_UNPACK_H

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -50,11 +50,13 @@
     #include <os_io_seproxyhal.h>
 
     #define MEMCOPY_ os_memmove
+    #define MEMSET_ os_memset
     #define MEMSET_BZERO_ explicit_bzero
 #else  // if not HAVE_BOLOS_SDK
     #include <string.h>
 
     #define MEMCOPY_ memcpy
+    #define MEMSET_ memset
     #define MEMSET_BZERO_ explicit_bzero
 #endif  // HAVE_BOLOS_SDK
 
@@ -67,6 +69,17 @@
 //
 // ---
 #define MEMCOPY MEMCOPY_
+
+
+////////////////////////////////////////////////////////////////////////////////
+// A platform wrapper for 'memset'. Fills a block of memory with a given value.
+//
+// @param void *ptr:    pointer to the object.
+// @param int value:    value to fill the block of memory.
+// @param size_t n:     number of bytes to set.
+//
+// ---
+#define MEMSET MEMSET_
 
 ////////////////////////////////////////////////////////////////////////////////
 // Zero-out a block of memory, avoiding compiler optimization.

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -56,10 +56,6 @@
 
     #define MEMCOPY_ memcpy
     #define MEMSET_BZERO_ explicit_bzero
-
-    // Ledger Nano SDK
-    // If using 8-byte numbers (e.g. uint64_t), use methods in 'utils/print.h'
-    #define SPRINTF(strbuf, ...) snprintf(strbuf, sizeof(strbuf), __VA_ARGS__)
 #endif  // HAVE_BOLOS_SDK
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -49,15 +49,52 @@
     #include <os.h>
     #include <os_io_seproxyhal.h>
 
-    #define bytecpy os_memmove
+    #define MEMCOPY_ os_memmove
+    #define MEMSET_BZERO_ explicit_bzero
 #else  // if not HAVE_BOLOS_SDK
     #include <string.h>
 
-    #define bytecpy memcpy
+    #define MEMCOPY_ memcpy
+    #define MEMSET_BZERO_ explicit_bzero
 
     // Ledger Nano SDK
     // If using 8-byte numbers (e.g. uint64_t), use methods in 'utils/print.h'
     #define SPRINTF(strbuf, ...) snprintf(strbuf, sizeof(strbuf), __VA_ARGS__)
 #endif  // HAVE_BOLOS_SDK
+
+////////////////////////////////////////////////////////////////////////////////
+// A platform wrapper for 'memcpy' / 'os_memmove'.
+//
+// @param void *dst:        pointer to the destination buffer.
+// @param const void *src:  pointer to the source buffer.
+// @param size_t n:         number of bytes to copy.
+//
+// ---
+#define MEMCOPY MEMCOPY_
+
+////////////////////////////////////////////////////////////////////////////////
+// Zero-out a block of memory, avoiding compiler optimization.
+//
+// @param void *ptr:    pointer to the object.
+// @param size_t len:   number of bytes to zero-out.
+//
+// ---
+#define MEMSET_BZERO MEMSET_BZERO_
+
+////////////////////////////////////////////////////////////////////////////////
+// Zero-out a block of memory with additional type-safety.
+//
+// TODO: use Static Assertion
+//
+// @param void *ptr:        pointer to the object.
+// @param void expected_t:  type of object to be zeroed-out.
+//
+// ---
+#define MEMSET_TYPE_BZERO(ptr, expected_t) do {     \
+    if (sizeof(expected_t) == sizeof(*(ptr))) {     \
+        MEMSET_BZERO(ptr, sizeof(expected_t));      \
+    }                                               \
+} while(0);
+
 
 #endif  // ARK_UTILS_H


### PR DESCRIPTION
## Summary

Improve naming, security, and overall implementation of files within the `utils` directory.

Since we never create pubkeyHashes and always receive an addressHash as an input in BOLOS environments, Ripemd160 hashing can be also removed .

- **`utils/hex`**
  - add U suffix to integer literals (avoids overflow, wrapping, etc).
  - add comments.
- **`utils/print`**
  - create new `print.h` file.
  - move `SNPRINTF` to `print.h`.
  - add `SPRINTF` macro.
  - update header includes.
  - add comments.
- **`utils/str`**
  - rename old `print.h` -> `str.h`.
  - rename `TOKEN_NAME_SIZE` -> `TOKEN_NAME_LEN`.
  - adjust `TokenAmountToString` token name logic.
  - add comments.
- **`utils/unpack`**
  - remove BOLOS SDK unpacking macros in favor of ours with better type-safety.
  - improve static global values.
  - add comments.
- **`utils/utils`**
  - rename `bytecpy` -> `MEMCOPY`.
  - add `MEMSET_BZERO` macro for `explicit_bzero`.
  - add `MEMSET_TYPE_BZERO` macro (type-safety).
  - add comments.
- **`crypto/hashing`**
  - `hash160`: **\*\*REMOVED\*\***

"Unsupported" docs are also updated with their relevant changes.

## Checklist

- [x] Documentation
- [x] Ready to be merged

## Additional Comments

Changes are non-breaking.
