### PR TITLE
deps(nanos-sdk): use firmware 1.6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           cd /opt/bolos/
           git clone https://github.com/LedgerHQ/nanos-secure-sdk.git
           cd nanos-secure-sdk/
-          git -c advice.detachedHead=false checkout tags/nanos-160
+          git -c advice.detachedHead=false checkout tags/nanos-161
 
       - name: Building the Ledger ARK app
         run: make
@@ -64,7 +64,7 @@ jobs:
           mkdir ./.github/workflows/artifacts
           cp ./bin/app.hex ./.github/workflows/artifacts/
           cp ./examples/example_helper.py ./.github/workflows/artifacts/
-          printf '#!/usr/bin/env bash\n\n# Artifact builds are for TESTING PURPOSES ONLY!\n# Never use this with personal funds.\n#\n# unzip the artifacts and run "bash ./flash.sh" to execute this script.\n#\n# Requirements:\n# - python3\n# - ledgerblue (pip3 install ledgerblue)\n#\n' >> ./.github/workflows/artifacts/flash.sh && printf "%s" 'python3 -m ledgerblue.loadApp --fileName app.hex --appName Ark --appFlags 0x240 --curve secp256k1 --path ' "\"44'/111'\"" ' --path ' "\"44'/1'\"" ' --targetId 0x31100004 --targetVersion="1.6.0" --icon "010000000000ffffffffffffffffffffff7ffe3ffc1ff89ff98ff1cff347e267e6ffffffffffffffff" --tlv --delete' >> ./.github/workflows/artifacts/flash.sh && printf '\n' >> ./.github/workflows/artifacts/flash.sh
+          printf '#!/usr/bin/env bash\n\n# Artifact builds are for TESTING PURPOSES ONLY!\n# Never use this with personal funds.\n#\n# unzip the artifacts and run "bash ./flash.sh" to execute this script.\n#\n# Requirements:\n# - python3\n# - ledgerblue (pip3 install ledgerblue)\n#\n' >> ./.github/workflows/artifacts/flash.sh && printf "%s" 'python3 -m ledgerblue.loadApp --fileName app.hex --appName Ark --appFlags 0x240 --curve secp256k1 --path ' "\"44'/111'\"" ' --path ' "\"44'/1'\"" ' --targetId 0x31100004 --targetVersion="1.6.1" --icon "010000000000ffffffffffffffffffffff7ffe3ffc1ff89ff98ff1cff347e267e6ffffffffffffffff" --tlv --delete' >> ./.github/workflows/artifacts/flash.sh && printf '\n' >> ./.github/workflows/artifacts/flash.sh
           printf '#!/usr/bin/env bash\n\npython3 example_helper.py --publickey\n' >> ./.github/workflows/artifacts/publickey.sh
           printf '#!/usr/bin/env bash\n\npython3 example_helper.py --message 416c6c2070617274732073686f756c6420676f20746f67657468657220776974686f757420666f7263696e672e20596f75206d7573742072656d656d62657220746861742074686520706172747320796f7520617265207265617373656d626c696e67207765726520646973617373656d626c656420627920796f752e205468657265666f72652c20696620796f752063616e277420676574207468656d20746f67657468657220616761696e2c207468657265206d757374206265206120726561736f6e2e20427920616c6c206d65616e732c20646f206e6f742075736520612068616d6d65722e207e2049424d204d616e75616c202d20283139373529\n' >> ./.github/workflows/artifacts/message.sh
           printf '#!/usr/bin/env bash\n\npython3 example_helper.py --tx ff0217010000000000010000000000000003a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933809698000000000000a08601000000000000000000171dfc69b54c7fe901e91d5a9ab78388645e2427ea\n' >> ./.github/workflows/artifacts/transfer.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 -   support MultiSignature Registration on the NanoX ([#80])
 
+### Changed
+
+-   upgraded `nanos-secure-sdk` version `160` -> `161` ([#94])
+
 ## [2.1.0] - 2020-04-06
 
 ### Added
@@ -54,4 +58,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#72]: https://github.com/ArkEcosystem/ledger/pull/72
 [2.1.0]: https://github.com/ArkEcosystem/ledger/compare/2.0.1...2.1.0
 [#80]: https://github.com/ArkEcosystem/ledger/pull/80
+[#94]: https://github.com/ArkEcosystem/ledger/pull/94
 [unreleased]: https://github.com/ArkEcosystem/ledger/compare/master...develop

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -33,11 +33,11 @@ if [ ! -d "/opt/bolos" ]; then
 fi
 
 if [ ! -d "/opt/bolos/SDK/nanos-secure-sdk" ]; then
-    printf "\n%s\n" "Fetching the Nano S SDK"
+    printf "\n%s\n" "Fetching the Nano S SDK 1.6.1"
     cd /opt/bolos/SDK || exit
     git clone https://github.com/LedgerHQ/nanos-secure-sdk.git
     cd nanos-secure-sdk/ || exit
-    git -c advice.detachedHead=false checkout tags/nanos-160
+    git -c advice.detachedHead=false checkout tags/nanos-161
 fi
 
 # The NanoX SDK is not currently available to the public.


### PR DESCRIPTION
## Summary

Update `nanos-secure-sdk` `1.6.0` -> `1.6.1`

- update vagrant machine 'provision' file
- update GH Action
- update CHANGELOG

## Checklist

- [x] Ready to be merged
